### PR TITLE
Feature/model versioning（add local version management for STM graph）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { EdgeCreationHint } from './app/components/EdgeCreationHint';
 import { ErrorState } from './app/components/ErrorState';
 import { LoadingState } from './app/components/LoadingState';
 import { TipsPanel } from './app/components/TipsPanel';
+import { VersionManagerModal } from './app/components/VersionManagerModal';
 import { useGraphEditor } from './app/hooks/useGraphEditor';
 import { NodeModal } from './nodes/nodeModal';
 import { TransitionModal } from './transitions/transitionModal';
@@ -43,6 +44,8 @@ function App() {
         initialNodeValues,
         currentTransition,
         stateNameMap,
+        versions,
+        isVersionModalOpen,
         onNodesChange,
         onConnect,
         onEdgeClick,
@@ -59,6 +62,11 @@ function App() {
         openAddNodeModal,
         closeNodeModal,
         closeTransitionModal,
+        saveCurrentVersion,
+        openVersionManager,
+        closeVersionManager,
+        restoreVersion,
+        deleteVersion,
     } = useGraphEditor();
 
     if (isLoading) {
@@ -76,6 +84,8 @@ function App() {
                 onToggleEdgeCreation={toggleEdgeCreationMode}
                 onLoadEdges={loadExistingEdges}
                 onSaveModel={handleSaveModel}
+                onSaveVersion={saveCurrentVersion}
+                onOpenVersionManager={openVersionManager}
                 onRelayout={handleReLayout}
                 onToggleSelfTransitions={toggleSelfTransitions}
                 onDeltaFilterChange={toggleDeltaFilter}
@@ -139,6 +149,14 @@ function App() {
                 onSave={handleSaveTransition}
                 transition={currentTransition}
                 stateNames={stateNameMap}
+            />
+
+            <VersionManagerModal
+                isOpen={isVersionModalOpen}
+                versions={versions}
+                onClose={closeVersionManager}
+                onRestore={restoreVersion}
+                onDelete={deleteVersion}
             />
         </div>
     );

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -7,6 +7,8 @@ interface GraphToolbarProps {
     onToggleEdgeCreation: () => void;
     onLoadEdges: () => void;
     onSaveModel: () => void | Promise<void>;
+    onSaveVersion: () => void;
+    onOpenVersionManager: () => void;
     onRelayout: () => void;
     onToggleSelfTransitions: () => void;
     onDeltaFilterChange: (option: DeltaFilterOption) => void;
@@ -23,6 +25,8 @@ export function GraphToolbar({
     onLoadEdges,
     onSaveModel,
     onRelayout,
+    onSaveVersion,
+    onOpenVersionManager,
     onToggleSelfTransitions,
     onDeltaFilterChange,
     edgeCreationMode,
@@ -58,6 +62,14 @@ export function GraphToolbar({
                 className={`button button-success ${isSaving ? 'button-disabled' : ''}`}
             >
                 {isSaving ? '💾 Saving...' : '💾 Save Model'}
+            </button>
+
+            <button onClick={onSaveVersion} className="button button-secondary">
+                💾 Save Version
+            </button>
+
+            <button onClick={onOpenVersionManager} className="button button-secondary">
+                🗂 Versions
             </button>
 
             <button onClick={onRelayout} className="button button-secondary">

--- a/src/app/components/VersionManagerModal.tsx
+++ b/src/app/components/VersionManagerModal.tsx
@@ -1,0 +1,135 @@
+import { GraphModelVersion } from '../types';
+
+interface VersionManagerModalProps {
+    isOpen: boolean;
+    versions: GraphModelVersion[];
+    onClose: () => void;
+    onRestore: (id: string) => void;
+    onDelete: (id: string) => void;
+}
+
+export function VersionManagerModal({
+    isOpen,
+    versions,
+    onClose,
+    onRestore,
+    onDelete,
+}: VersionManagerModalProps) {
+    if (!isOpen) {
+        return null;
+    }
+
+    const handleDelete = (event: React.MouseEvent<HTMLButtonElement>, id: string) => {
+        event.stopPropagation();
+        onDelete(id);
+    };
+
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                zIndex: 1100,
+            }}
+            onClick={onClose}
+        >
+            <div
+                style={{
+                    backgroundColor: '#fff',
+                    borderRadius: '8px',
+                    padding: '20px',
+                    width: '500px',
+                    maxWidth: '90%',
+                    maxHeight: '80vh',
+                    overflowY: 'auto',
+                    boxShadow: '0 12px 32px rgba(0,0,0,0.2)',
+                }}
+                onClick={(event) => event.stopPropagation()}
+            >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <h2 style={{ margin: 0 }}>Model Versions</h2>
+                    <button
+                        onClick={onClose}
+                        style={{
+                            background: 'none',
+                            border: 'none',
+                            fontSize: '18px',
+                            cursor: 'pointer',
+                        }}
+                        aria-label="Close version manager"
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                {versions.length === 0 ? (
+                    <p style={{ marginTop: '20px' }}>
+                        No saved versions yet. Use &ldquo;Save Version&rdquo; after editing to keep a snapshot.
+                    </p>
+                ) : (
+                    <ul style={{ listStyle: 'none', padding: 0, marginTop: '20px', display: 'grid', gap: '12px' }}>
+                        {versions.map((version) => {
+                            const savedAt = new Date(version.savedAt);
+                            return (
+                                <li
+                                    key={version.id}
+                                    style={{
+                                        border: '1px solid #e5e7eb',
+                                        borderRadius: '6px',
+                                        padding: '12px 16px',
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        alignItems: 'center',
+                                        gap: '16px',
+                                    }}
+                                >
+                                    <div>
+                                        <div style={{ fontWeight: 600 }}>{version.name}</div>
+                                        <div style={{ fontSize: '12px', color: '#6b7280' }}>
+                                            Saved at {savedAt.toLocaleString()}
+                                        </div>
+                                    </div>
+                                    <div style={{ display: 'flex', gap: '8px' }}>
+                                        <button
+                                            onClick={() => onRestore(version.id)}
+                                            style={{
+                                                padding: '6px 12px',
+                                                borderRadius: '4px',
+                                                border: '1px solid #10b981',
+                                                backgroundColor: '#10b981',
+                                                color: '#fff',
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            Restore
+                                        </button>
+                                        <button
+                                            onClick={(event) => handleDelete(event, version.id)}
+                                            style={{
+                                                padding: '6px 12px',
+                                                borderRadius: '4px',
+                                                border: '1px solid #ef4444',
+                                                backgroundColor: '#fff',
+                                                color: '#ef4444',
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            Delete
+                                        </button>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/app/hooks/graphVersions.ts
+++ b/src/app/hooks/graphVersions.ts
@@ -1,0 +1,112 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import { AppNode } from '../../nodes/types';
+import { statesToNodes, BMRGData } from '../../utils/stateTransition';
+import {
+    loadVersions,
+    saveVersion as persistVersion,
+    deleteVersion as persistDeleteVersion,
+} from '../../utils/versionStorage';
+import { GraphModelVersion } from '../types';
+
+interface Dependencies {
+    getData: () => BMRGData | null;
+    setData: Dispatch<SetStateAction<BMRGData | null>>;
+    setNodes: Dispatch<SetStateAction<AppNode[]>>;
+    handleNodeLabelChange: (id: string, label: string) => void;
+    handleNodeClick: (id: string) => void;
+    rebuildEdges: (options?: { transitions?: BMRGData['transitions']; dataOverride?: BMRGData | null }) => void;
+    getVersions: () => GraphModelVersion[];
+    setVersions: Dispatch<SetStateAction<GraphModelVersion[]>>;
+    setIsVersionModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+function cloneData(data: BMRGData): BMRGData {
+    return JSON.parse(JSON.stringify(data)) as BMRGData;
+}
+
+function createVersionName(timestamp: Date, existing: GraphModelVersion[]): string {
+    const base = `Version ${timestamp.toLocaleString()}`;
+    const duplicates = existing.filter((version) => version.name.startsWith(base)).length;
+    return duplicates ? `${base} (${duplicates + 1})` : base;
+}
+
+function createId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+        return crypto.randomUUID();
+    }
+    return `version-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+}
+
+export function createVersionActions({
+    getData,
+    setData,
+    setNodes,
+    handleNodeLabelChange,
+    handleNodeClick,
+    rebuildEdges,
+    getVersions,
+    setVersions,
+    setIsVersionModalOpen,
+}: Dependencies) {
+    const initialise = () => {
+        const stored = loadVersions();
+        setVersions(stored);
+    };
+
+    const openVersionManager = () => setIsVersionModalOpen(true);
+    const closeVersionManager = () => setIsVersionModalOpen(false);
+
+    const saveCurrentVersion = () => {
+        const data = getData();
+        if (!data) {
+            return;
+        }
+
+        const timestamp = new Date();
+        const existing = getVersions();
+        const version: GraphModelVersion = {
+            id: createId(),
+            name: createVersionName(timestamp, existing),
+            savedAt: timestamp.toISOString(),
+            data: cloneData(data),
+        };
+
+        const next = persistVersion(version);
+        setVersions(next);
+        setIsVersionModalOpen(true);
+    };
+
+    const restoreVersion = (id: string) => {
+        const version = getVersions().find((item) => item.id === id);
+        if (!version) {
+            return;
+        }
+
+        const cloned = cloneData(version.data);
+        setData(cloned);
+        const nextNodes = statesToNodes(
+            cloned.states,
+            handleNodeLabelChange,
+            handleNodeClick,
+            cloned.transitions,
+        );
+        setNodes(nextNodes);
+        rebuildEdges({ transitions: cloned.transitions, dataOverride: cloned });
+        setIsVersionModalOpen(false);
+    };
+
+    const deleteVersion = (id: string) => {
+        const next = persistDeleteVersion(id);
+        setVersions(next);
+    };
+
+    return {
+        initialise,
+        openVersionManager,
+        closeVersionManager,
+        saveCurrentVersion,
+        restoreVersion,
+        deleteVersion,
+    };
+}

--- a/src/app/hooks/useGraphBaseState.ts
+++ b/src/app/hooks/useGraphBaseState.ts
@@ -10,7 +10,7 @@ import {
 import { NodeAttributes } from '../../nodes/nodeModal';
 import { AppNode } from '../../nodes/types';
 import { BMRGData, TransitionData } from '../../utils/stateTransition';
-import { DeltaFilterOption } from '../types';
+import { DeltaFilterOption, GraphModelVersion } from '../types';
 
 export interface GraphBaseState {
     nodes: AppNode[];
@@ -46,6 +46,10 @@ export interface GraphBaseState {
     setError: React.Dispatch<React.SetStateAction<string | null>>;
     isSaving: boolean;
     setIsSaving: React.Dispatch<React.SetStateAction<boolean>>;
+    versions: GraphModelVersion[];
+    setVersions: React.Dispatch<React.SetStateAction<GraphModelVersion[]>>;
+    isVersionModalOpen: boolean;
+    setIsVersionModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export function useGraphBaseState(): GraphBaseState {
@@ -70,6 +74,8 @@ export function useGraphBaseState(): GraphBaseState {
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [isSaving, setIsSaving] = useState(false);
+    const [versions, setVersions] = useState<GraphModelVersion[]>([]);
+    const [isVersionModalOpen, setIsVersionModalOpen] = useState(false);
 
     return {
         nodes,
@@ -105,5 +111,9 @@ export function useGraphBaseState(): GraphBaseState {
         setError,
         isSaving,
         setIsSaving,
+        versions,
+        setVersions,
+        isVersionModalOpen,
+        setIsVersionModalOpen,
     };
 }

--- a/src/app/hooks/useGraphEditor.ts
+++ b/src/app/hooks/useGraphEditor.ts
@@ -12,6 +12,7 @@ import { createTransitionCreator, createEdgeHandlers } from './graphTransitions'
 import { createNodeHandlers } from './graphNodes';
 import { createFilterActions } from './graphFilters';
 import { createModelActions } from './graphModel';
+import { createVersionActions } from './graphVersions';
 
 export function useGraphEditor(): UseGraphEditorResult {
     const state = useGraphBaseState();
@@ -83,8 +84,21 @@ export function useGraphEditor(): UseGraphEditorResult {
         setData: state.setBmrgData,
     });
 
+    const versionActions = createVersionActions({
+        getData: () => state.bmrgData,
+        setData: state.setBmrgData,
+        setNodes: state.setNodes,
+        handleNodeLabelChange,
+        handleNodeClick: nodeHandlers.handleNodeClick,
+        rebuildEdges,
+        getVersions: () => state.versions,
+        setVersions: state.setVersions,
+        setIsVersionModalOpen: state.setIsVersionModalOpen,
+    });
+
     useEffect(() => {
         modelActions.initialise();
+        versionActions.initialise();
     }, []);
 
     const nodesWithCallbacks = state.nodes.map((node) => ({
@@ -140,6 +154,8 @@ export function useGraphEditor(): UseGraphEditorResult {
         initialNodeValues: state.initialNodeValues,
         currentTransition: state.currentTransition,
         stateNameMap,
+        versions: state.versions,
+        isVersionModalOpen: state.isVersionModalOpen,
         onNodesChange: state.onNodesChange,
         onConnect,
         onEdgeClick: edgeHandlers.onEdgeClick,
@@ -156,5 +172,10 @@ export function useGraphEditor(): UseGraphEditorResult {
         openAddNodeModal: nodeHandlers.openAddNodeModal,
         closeNodeModal: nodeHandlers.closeNodeModal,
         closeTransitionModal,
+        saveCurrentVersion: versionActions.saveCurrentVersion,
+        openVersionManager: versionActions.openVersionManager,
+        closeVersionManager: versionActions.closeVersionManager,
+        restoreVersion: versionActions.restoreVersion,
+        deleteVersion: versionActions.deleteVersion,
     };
 }

--- a/src/app/hooks/useGraphEditor.types.ts
+++ b/src/app/hooks/useGraphEditor.types.ts
@@ -12,7 +12,7 @@ import {
 import { NodeAttributes } from '../../nodes/nodeModal';
 import { AppNode } from '../../nodes/types';
 import { BMRGData, TransitionData } from '../../utils/stateTransition';
-import { DeltaFilterOption } from '../types';
+import { DeltaFilterOption, GraphModelVersion } from '../types';
 
 export interface UseGraphEditorResult {
     nodesWithCallbacks: AppNode[];
@@ -34,6 +34,8 @@ export interface UseGraphEditorResult {
     initialNodeValues: NodeAttributes | undefined;
     currentTransition: TransitionData | null;
     stateNameMap: Record<number, string>;
+    versions: GraphModelVersion[];
+    isVersionModalOpen: boolean;
     onNodesChange: OnNodesChange<AppNode>;
     onConnect: OnConnect;
     onEdgeClick: EdgeMouseHandler;
@@ -50,4 +52,9 @@ export interface UseGraphEditorResult {
     openAddNodeModal: () => void;
     closeNodeModal: () => void;
     closeTransitionModal: () => void;
+    saveCurrentVersion: () => void;
+    openVersionManager: () => void;
+    closeVersionManager: () => void;
+    restoreVersion: (id: string) => void;
+    deleteVersion: (id: string) => void;
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,1 +1,10 @@
+import { BMRGData } from '../utils/stateTransition';
+
 export type DeltaFilterOption = 'all' | 'positive' | 'neutral' | 'negative';
+
+export interface GraphModelVersion {
+    id: string;
+    name: string;
+    savedAt: string;
+    data: BMRGData;
+}

--- a/src/utils/versionStorage.ts
+++ b/src/utils/versionStorage.ts
@@ -1,0 +1,62 @@
+import { GraphModelVersion } from '../app/types';
+
+const STORAGE_KEY = 'stmCreator.versions';
+
+function hasLocalStorage(): boolean {
+    try {
+        return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+    } catch {
+        return false;
+    }
+}
+
+export function loadVersions(): GraphModelVersion[] {
+    if (!hasLocalStorage()) {
+        return [];
+    }
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as GraphModelVersion[];
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        console.error('Failed to parse stored versions', error);
+        return [];
+    }
+}
+
+export function persistVersions(versions: GraphModelVersion[]): void {
+    if (!hasLocalStorage()) {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(versions));
+    } catch (error) {
+        console.error('Failed to store versions', error);
+    }
+}
+
+export function saveVersion(version: GraphModelVersion): GraphModelVersion[] {
+    const versions = loadVersions();
+    const next = [version, ...versions].slice(0, 50);
+    persistVersions(next);
+    return next;
+}
+
+export function deleteVersion(id: string): GraphModelVersion[] {
+    const versions = loadVersions().filter((item) => item.id !== id);
+    persistVersions(versions);
+    return versions;
+}
+
+export function clearVersions(): void {
+    if (!hasLocalStorage()) {
+        return;
+    }
+    window.localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
Adds client-side versioning so users can snapshot, list, restore, and delete STM models:
- declare GraphModelVersion type and versionStorage helper using localStorage
- extend core graph hooks to manage version state and rebuild nodes/edges on restore
- surface “Save Version” and “Versions” controls plus a modal for managing snapshots

Testing:
-  Manually saved multiple versions, refreshed, confirmed they persist
-  Restored a saved version and verified nodes/edges update accordingly
-  Deleted a version and ensured it disappears from the modal