### PR TITLE
1.add converters between BMRGData and EKS JSON schema with validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,8 @@ function App() {
         closeVersionManager,
         restoreVersion,
         deleteVersion,
+        exportToEKS,
+        importFromEKS,
     } = useGraphEditor();
 
     if (isLoading) {
@@ -86,6 +88,8 @@ function App() {
                 onSaveModel={handleSaveModel}
                 onSaveVersion={saveCurrentVersion}
                 onOpenVersionManager={openVersionManager}
+                onImportEKS={importFromEKS}
+                onExportEKS={exportToEKS}
                 onRelayout={handleReLayout}
                 onToggleSelfTransitions={toggleSelfTransitions}
                 onDeltaFilterChange={toggleDeltaFilter}

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -1,4 +1,6 @@
 
+import { useRef } from 'react';
+
 import { BMRGData } from '../../utils/stateTransition';
 import { DeltaFilterOption } from '../types';
 
@@ -9,6 +11,8 @@ interface GraphToolbarProps {
     onSaveModel: () => void | Promise<void>;
     onSaveVersion: () => void;
     onOpenVersionManager: () => void;
+    onImportEKS: (file: File) => void | Promise<void>;
+    onExportEKS: () => void;
     onRelayout: () => void;
     onToggleSelfTransitions: () => void;
     onDeltaFilterChange: (option: DeltaFilterOption) => void;
@@ -27,6 +31,8 @@ export function GraphToolbar({
     onRelayout,
     onSaveVersion,
     onOpenVersionManager,
+    onImportEKS,
+    onExportEKS,
     onToggleSelfTransitions,
     onDeltaFilterChange,
     edgeCreationMode,
@@ -35,12 +41,35 @@ export function GraphToolbar({
     deltaFilter,
     bmrgData,
 }: GraphToolbarProps) {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleImportClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            onImportEKS(file);
+        }
+        // Reset so the same file can be selected again if needed
+        event.target.value = '';
+    };
+
     const plausibleTransitionCount = bmrgData
         ? bmrgData.transitions.filter((transition) => transition.time_25 === 1).length
         : 0;
 
     return (
         <div className="controls-toolbar">
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json"
+                style={{ display: 'none' }}
+                onChange={handleFileChange}
+            />
+
             <button onClick={onAddNode} className="button button-primary">
                 ➕ Add Node
             </button>
@@ -70,6 +99,14 @@ export function GraphToolbar({
 
             <button onClick={onOpenVersionManager} className="button button-secondary">
                 🗂 Versions
+            </button>
+
+            <button onClick={handleImportClick} className="button button-secondary">
+                📥 Import EKS
+            </button>
+
+            <button onClick={onExportEKS} className="button button-secondary">
+                📤 Export EKS
             </button>
 
             <button onClick={onRelayout} className="button button-secondary">

--- a/src/app/hooks/graphImportExport.ts
+++ b/src/app/hooks/graphImportExport.ts
@@ -1,0 +1,82 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import { AppNode } from '../../nodes/types';
+import { BMRGData } from '../../utils/stateTransition';
+import { fromEKSModel, toEKSModel, EKSModel } from '../../utils/eksJson';
+
+interface Dependencies {
+    getData: () => BMRGData | null;
+    setData: Dispatch<SetStateAction<BMRGData | null>>;
+    setNodes: Dispatch<SetStateAction<AppNode[]>>;
+    rebuildEdges: (options?: { transitions?: BMRGData['transitions']; dataOverride?: BMRGData | null }) => void;
+    handleNodeLabelChange: (id: string, label: string) => void;
+    handleNodeClick: (id: string) => void;
+    statesToNodes: (
+        states: BMRGData['states'],
+        onLabelChange: (id: string, newLabel: string) => void,
+        onNodeClick: (id: string) => void,
+        transitions: BMRGData['transitions'],
+    ) => AppNode[];
+}
+
+function downloadJsonFile(filename: string, content: string) {
+    const blob = new Blob([content], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+}
+
+export function createImportExportActions({
+    getData,
+    setData,
+    setNodes,
+    rebuildEdges,
+    handleNodeLabelChange,
+    handleNodeClick,
+    statesToNodes,
+}: Dependencies) {
+    const exportToEKS = () => {
+        const data = getData();
+        if (!data) {
+            window.alert('No model available to export.');
+            return;
+        }
+
+        const eksModel = toEKSModel(data);
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const filename = `${eksModel.name ?? 'stm-model'}-${timestamp}.json`;
+        downloadJsonFile(filename, JSON.stringify(eksModel, null, 2));
+    };
+
+    const importFromEKS = async (file: File) => {
+        try {
+            const text = await file.text();
+            const parsed = JSON.parse(text) as EKSModel;
+            const bmrgData = fromEKSModel(parsed);
+            setData(bmrgData);
+            const nodes = statesToNodes(
+                bmrgData.states,
+                handleNodeLabelChange,
+                handleNodeClick,
+                bmrgData.transitions,
+            );
+            setNodes(nodes);
+            rebuildEdges({ transitions: bmrgData.transitions, dataOverride: bmrgData });
+        } catch (error) {
+            console.error('Failed to import EKS JSON', error);
+            const message =
+                error instanceof Error ? error.message : 'Unknown error while importing JSON.';
+            window.alert(`Invalid EKS JSON: ${message}`);
+        }
+    };
+
+    return {
+        exportToEKS,
+        importFromEKS,
+    };
+}

--- a/src/app/hooks/useGraphEditor.ts
+++ b/src/app/hooks/useGraphEditor.ts
@@ -4,7 +4,7 @@ import { addEdge, Connection, OnConnect } from '@xyflow/react';
 
 import { DEFAULT_EDGE_OPTIONS, EXTENDED_EDGE_TYPES, EXTENDED_NODE_TYPES } from './graphConstants';
 import { UseGraphEditorResult } from './useGraphEditor.types';
-import { TransitionData } from '../../utils/stateTransition';
+import { TransitionData, statesToNodes } from '../../utils/stateTransition';
 import { useGraphBaseState } from './useGraphBaseState';
 import { buildStateNameMap, updateNodeLabel } from './graphMutations';
 import { createRebuildEdges } from './graphRebuilder';
@@ -12,6 +12,7 @@ import { createTransitionCreator, createEdgeHandlers } from './graphTransitions'
 import { createNodeHandlers } from './graphNodes';
 import { createFilterActions } from './graphFilters';
 import { createModelActions } from './graphModel';
+import { createImportExportActions } from './graphImportExport';
 import { createVersionActions } from './graphVersions';
 
 export function useGraphEditor(): UseGraphEditorResult {
@@ -96,6 +97,16 @@ export function useGraphEditor(): UseGraphEditorResult {
         setIsVersionModalOpen: state.setIsVersionModalOpen,
     });
 
+    const importExportActions = createImportExportActions({
+        getData: () => state.bmrgData,
+        setData: state.setBmrgData,
+        setNodes: state.setNodes,
+        rebuildEdges,
+        handleNodeLabelChange,
+        handleNodeClick: nodeHandlers.handleNodeClick,
+        statesToNodes,
+    });
+
     useEffect(() => {
         modelActions.initialise();
         versionActions.initialise();
@@ -177,5 +188,7 @@ export function useGraphEditor(): UseGraphEditorResult {
         closeVersionManager: versionActions.closeVersionManager,
         restoreVersion: versionActions.restoreVersion,
         deleteVersion: versionActions.deleteVersion,
+        exportToEKS: importExportActions.exportToEKS,
+        importFromEKS: importExportActions.importFromEKS,
     };
 }

--- a/src/app/hooks/useGraphEditor.types.ts
+++ b/src/app/hooks/useGraphEditor.types.ts
@@ -57,4 +57,6 @@ export interface UseGraphEditorResult {
     closeVersionManager: () => void;
     restoreVersion: (id: string) => void;
     deleteVersion: (id: string) => void;
+    exportToEKS: () => void;
+    importFromEKS: (file: File) => Promise<void>;
 }

--- a/src/utils/eksJson.ts
+++ b/src/utils/eksJson.ts
@@ -1,0 +1,163 @@
+import { BMRGData, StateData, TransitionData } from './stateTransition';
+
+export interface EKSState {
+    id: number;
+    name: string;
+    condition: {
+        lower: number;
+        upper: number;
+    };
+    estimate: number;
+}
+
+export interface EKSTransition {
+    id: number;
+    start_state_id: number;
+    end_state_id: number;
+    time_25: number;
+    time_100: number;
+    likelihood_25: number;
+    likelihood_100: number;
+    delta: number;
+}
+
+export interface EKSModel {
+    name?: string;
+    description?: string;
+    states: EKSState[];
+    transitions: EKSTransition[];
+}
+
+export function toEKSModel(data: BMRGData): EKSModel {
+    const states: EKSState[] = data.states.map((state) => ({
+        id: state.state_id,
+        name: state.state_name,
+        condition: {
+            lower: state.condition_lower,
+            upper: state.condition_upper,
+        },
+        estimate: state.eks_condition_estimate,
+    }));
+
+    const transitions: EKSTransition[] = data.transitions.map((transition) => ({
+        id: transition.transition_id,
+        start_state_id: transition.start_state_id,
+        end_state_id: transition.end_state_id,
+        time_25: transition.time_25,
+        time_100: transition.time_100,
+        likelihood_25: transition.likelihood_25,
+        likelihood_100: transition.likelihood_100,
+        delta: transition.transition_delta,
+    }));
+
+    return {
+        name: data.stm_name,
+        states,
+        transitions,
+    };
+}
+
+function createBaseState(id: number, name: string, lower: number, upper: number, estimate: number): StateData {
+    return {
+        state_id: id,
+        state_name: name,
+        vast_state: {
+            vast_class: '',
+            vast_name: '',
+            vast_eks_state: -9999,
+            eks_overstorey_class: '',
+            eks_understorey_class: '',
+            eks_substate: '',
+            link: '',
+        },
+        condition_upper: upper,
+        condition_lower: lower,
+        eks_condition_estimate: estimate,
+        elicitation_type: 'imported',
+        attributes: null,
+    };
+}
+
+export function fromEKSModel(model: EKSModel): BMRGData {
+    if (!Array.isArray(model.states) || !Array.isArray(model.transitions)) {
+        throw new Error('EKS JSON must contain "states" and "transitions" arrays.');
+    }
+
+    const states = model.states.map((state) => {
+        if (
+            typeof state.id !== 'number' ||
+            typeof state.name !== 'string' ||
+            !state.condition ||
+            typeof state.condition.lower !== 'number' ||
+            typeof state.condition.upper !== 'number'
+        ) {
+            throw new Error('Each state requires numeric "id", string "name", and numeric condition bounds.');
+        }
+
+        return createBaseState(
+            state.id,
+            state.name,
+            state.condition.lower,
+            state.condition.upper,
+            typeof state.estimate === 'number' ? state.estimate : -9999,
+        );
+    });
+
+    const stateNameMap = states.reduce<Record<number, string>>((acc, state) => {
+        acc[state.state_id] = state.state_name;
+        return acc;
+    }, {});
+
+    const transitions: TransitionData[] = model.transitions.map((transition) => {
+        if (
+            typeof transition.id !== 'number' ||
+            typeof transition.start_state_id !== 'number' ||
+            typeof transition.end_state_id !== 'number'
+        ) {
+            throw new Error('Each transition requires numeric id, start_state_id, and end_state_id.');
+        }
+
+        const startName = stateNameMap[transition.start_state_id] ?? `State ${transition.start_state_id}`;
+        const endName = stateNameMap[transition.end_state_id] ?? `State ${transition.end_state_id}`;
+
+        return {
+            transition_id: transition.id,
+            stm_name: model.name ?? fallbackNamePlaceholder(),
+            start_state: startName,
+            start_state_id: transition.start_state_id,
+            end_state: endName,
+            end_state_id: transition.end_state_id,
+            time_25: typeof transition.time_25 === 'number' ? transition.time_25 : 0,
+            time_100: typeof transition.time_100 === 'number' ? transition.time_100 : 0,
+            likelihood_25: typeof transition.likelihood_25 === 'number' ? transition.likelihood_25 : 0,
+            likelihood_100: typeof transition.likelihood_100 === 'number' ? transition.likelihood_100 : 0,
+            notes: '',
+            causal_chain: [],
+            transition_delta: typeof transition.delta === 'number' ? transition.delta : 0,
+        };
+    });
+
+    return {
+        stm_name: model.name ?? fallbackNamePlaceholder(),
+        version: '',
+        release_date: '',
+        authorised_by: '',
+        contributing_experts: [],
+        region: '',
+        region_id: 0,
+        climate: '',
+        ecosystem_type: '',
+        aus_eco_archetype_code: 0,
+        aus_eco_archetype_name: '',
+        aus_eco_umbrella_code: 0,
+        peer_reviewed: '',
+        no_peer_reviewers: 0,
+        states,
+        transitions,
+        method_alignment: '',
+    };
+}
+
+function fallbackNamePlaceholder(): string {
+    return 'Imported STM';
+}


### PR DESCRIPTION
Enables interoperability with PLANR/STM datasets by supporting EKS JSON import/export:
- add converters between the internal BMRGData model and the EKS JSON schema (states with condition/estimate, transitions with timing/likelihood/delta) plus validation
- extend graph editor hooks to export the current STM snapshot and import a JSON file, rebuilding nodes/edges on success and surfacing descriptive errors on failure
- expose “Import EKS” / “Export EKS” controls in the toolbar so users can download snapshots or load external models directly in the UI

Testing：
-  Exported an STM and verified JSON includes required state/transition fields
-  Imported a valid EKS JSON and confirmed nodes/edges render correctly
-  Tried an invalid JSON and saw the intended error alert