### PR TITLE
Refactor editor page UI layout and theme (#38)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,423 +1,575 @@
-/* App container */
+/* ─── APP CONTAINER ─── */
 .app-container {
-    width: 100vw;
-    height: 100vh;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-/* Controls toolbar */
-.controls-toolbar {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 10;
-    display: flex;
-    gap: 10px;
+/* ─── TOOLBAR ─── */
+.toolbar {
+  height: var(--toolbar-h);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px;
+  position: relative;
+  z-index: 100;
+  flex-shrink: 0;
 }
 
-/* Button styles */
-.button {
-    padding: 8px 12px;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+.toolbar-logo {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-right: 12px;
+  padding-right: 16px;
+  border-right: 1px solid var(--border);
+  white-space: nowrap;
 }
 
-.button-primary {
-    background: #007bff;
+.tb-btn {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  transition: all .15s;
 }
 
-.button-success {
-    background: #28a745;
+.tb-btn:hover {
+  background: var(--surface2);
+  color: var(--text);
+  border-color: var(--border-light);
 }
 
-.button-secondary {
-    background: #6c757d;
+.tb-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
-.button-info {
-    background: #17a2b8;
+.tb-btn.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
-.button-danger {
-    background: #dc3545;
+.tb-btn.primary:hover {
+  background: var(--accent-hover);
 }
 
-.button-disabled {
-    opacity: 0.7;
-    cursor: default;
+.tb-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
-/* Info panel */
-.info-panel {
-    padding: 8px 12px;
-    background: #f8f9fa;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    font-size: 14px;
-    display: flex;
-    align-items: center;
+.tb-btn.active:hover {
+  background: var(--accent-hover);
 }
 
-.info-separator {
-    margin: 0 10px;
+.tb-btn svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
 }
 
-.info-text-muted {
-    font-size: 12px;
-    opacity: 0.7;
+.tb-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+  margin: 0 4px;
+  flex-shrink: 0;
 }
 
-/* Tips panel */
-.tips-panel {
-    padding: 8px 12px;
-    background: white;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+.tb-spacer {
+  flex: 1;
 }
 
-.tips-title {
-    margin: 0 0 8px 0;
+/* ─── HEADER ─── */
+.header-bar {
+  height: var(--header-h);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 16px;
+  position: relative;
+  z-index: 99;
+  flex-shrink: 0;
 }
 
-.tips-item {
-    margin: 0 0 4px 0;
-    font-size: 12px;
+.model-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
 }
 
-/* Loading screen */
-.loading-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    flex-direction: column;
-    gap: 10px;
+.meta-pill {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: 'DM Mono', monospace;
+  color: var(--text-muted);
 }
 
-.loading-text {
-    font-size: 24px;
-    font-weight: bold;
+.meta-pill .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
 }
 
-.loading-spinner {
-    width: 50px;
-    height: 50px;
-    border: 5px solid #f3f3f3;
-    border-top: 5px solid #3498db;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
+.dot-green { background: var(--accent); }
+.dot-amber { background: var(--amber); }
+
+/* ─── WORKSPACE ─── */
+.workspace {
+  display: flex;
+  flex: 1;
+  position: relative;
+  overflow: hidden;
 }
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+/* ─── LEFT SIDEBAR ─── */
+.sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-/* Error screen */
-.error-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    flex-direction: column;
-    gap: 20px;
-    padding: 20px;
-    text-align: center;
+.sidebar-section {
+  padding: 14px 14px 10px;
 }
 
-.error-title {
-    font-size: 24px;
-    font-weight: bold;
-    color: #e74c3c;
+.sidebar-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 10px;
 }
 
-.error-button {
-    padding: 10px 20px;
-    background: #3498db;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+.sidebar-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 8px 14px;
 }
-/* Edge creation mode styles */
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  cursor: default;
+}
+
+.legend-swatch {
+  width: 28px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legend-text {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.legend-count {
+  margin-left: auto;
+  font-size: 10px;
+  font-family: 'DM Mono', monospace;
+  color: var(--text-dim);
+}
+
+/* ─── CANVAS AREA ─── */
+.canvas-area {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ─── RIGHT PANEL ─── */
+.right-panel {
+  width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  transition: width .25s cubic-bezier(.4,0,.2,1);
+  flex-shrink: 0;
+}
+
+.right-panel.open {
+  width: 260px;
+}
+
+.rp-inner {
+  width: 260px;
+  padding: 16px;
+}
+
+.rp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.rp-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.rp-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+}
+
+.rp-close:hover {
+  color: var(--text);
+}
+
+.tip-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+}
+
+.tip-head {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  margin-bottom: 5px;
+}
+
+.tip-text {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.tip-text kbd {
+  background: var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+}
+
+/* ─── STATUS BAR ─── */
+.statusbar {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 5px 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 11px;
+  font-family: 'DM Mono', monospace;
+  color: var(--text-muted);
+  z-index: 50;
+  box-shadow: 0 4px 16px rgba(0,0,0,.08);
+  pointer-events: none;
+}
+
+.statusbar-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.statusbar span {
+  color: var(--text-dim);
+}
+
+.statusbar b {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* ─── EDGE CREATION MODE ─── */
 .edge-creation-active .node-container {
-    cursor: crosshair !important;
+  cursor: crosshair !important;
 }
 
-/* Highlight for selected node during edge creation */
 .node-selected {
-    box-shadow: 0 0 0 4px #007bff, 0 2px 5px rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0 0 0 4px var(--accent), 0 2px 5px rgba(0, 0, 0, 0.1) !important;
 }
 
-/* Custom button for edge creation mode */
-.button-edge-creation {
-    background: #007bff;
-    position: relative;
-}
-
-.button-edge-creation.active {
-    background: #28a745;
-}
-
-.button-edge-creation.active::after {
-    content: '';
-    position: absolute;
-    top: 3px;
-    right: 3px;
-    width: 8px;
-    height: 8px;
-    background-color: #fff;
-    border-radius: 50%;
-    animation: pulse 1.5s infinite;
-}
-
-@keyframes pulse {
-    0% {
-        transform: scale(0.95);
-        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.7);
-    }
-
-    70% {
-        transform: scale(1);
-        box-shadow: 0 0 0 8px rgba(255, 255, 255, 0);
-    }
-
-    100% {
-        transform: scale(0.95);
-        box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
-    }
-}
-
-/* Instruction overlay during edge creation */
 .edge-creation-help {
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
-    padding: 8px 16px;
-    border-radius: 20px;
-    font-size: 14px;
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    animation: fade-in 0.3s ease-in-out;
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 12px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 4px 16px rgba(0,0,0,.08);
+  animation: fade-in 0.3s ease-in-out;
+  font-family: 'DM Mono', monospace;
 }
 
 .edge-creation-help-icon {
-    margin-right: 8px;
-    font-size: 18px;
+  margin-right: 8px;
+  font-size: 18px;
 }
 
 @keyframes fade-in {
-    from {
-        opacity: 0;
-        transform: translate(-50%, 10px);
-    }
-    to {
-        opacity: 1;
-        transform: translate(-50%, 0);
-    }
+  from { opacity: 0; transform: translate(-50%, 10px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
 }
 
-/* Add these styles to your App.css file */
-
-/* Filter group styling */
-.filter-group {
-    display: flex;
-    align-items: center;
-    background: #f8f9fa;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    padding: 5px 10px;
-    margin-left: 10px;
+/* ─── LOADING ─── */
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--bg);
 }
 
-.filter-label {
-    margin-right: 10px;
-    font-size: 14px;
-    color: #495057;
-    white-space: nowrap;
+.loading-text {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
 }
 
-/* Filter button styling */
-.button-filter {
-    background: #e9ecef;
-    color: #495057;
-    font-size: 12px;
-    padding: 4px 8px;
-    margin-right: 5px;
-    transition: all 0.2s ease;
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border);
+  border-top: 3px solid var(--accent);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
 }
 
-.button-filter:last-child {
-    margin-right: 0;
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
-.button-filter.active {
-    background: #007bff;
-    color: white;
-    transform: scale(1.05);
-    animation: pulse-filter 1s ease-in-out;
+/* ─── ERROR ─── */
+.error-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  text-align: center;
+  background: var(--bg);
 }
 
-/* Specific filter types */
-.button-filter.positive {
-    border-left: 3px solid #28a745;
+.error-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--red);
 }
 
-.button-filter.positive.active {
-    background: #28a745;
+.error-button {
+  padding: 8px 16px;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
 }
 
-.button-filter.neutral {
-    border-left: 3px solid #6c757d;
+.error-button:hover {
+  background: var(--accent-hover);
 }
 
-.button-filter.neutral.active {
-    background: #6c757d;
+/* ─── MODAL OVERLAY (shared) ─── */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
 }
 
-.button-filter.negative {
-    border-left: 3px solid #dc3545;
+.modal-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--node-r);
+  padding: 20px;
+  max-width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 12px 32px rgba(0,0,0,.12);
 }
 
-.button-filter.negative.active {
-    background: #dc3545;
+/* ─── NODE ANIMATIONS ─── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-/* Info panel badge for active filter */
-.delta-filter-badge {
-    font-size: 12px;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-weight: bold;
+/* ─── REACT FLOW OVERRIDES ─── */
+.react-flow__controls {
+  box-shadow: 0 4px 16px rgba(0,0,0,.06) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 6px !important;
 }
 
-.delta-filter-badge.positive {
-    background-color: #d4edda;
-    color: #155724;
+.react-flow__controls-button {
+  border-bottom: 1px solid var(--border) !important;
+  background: var(--surface) !important;
+  fill: var(--text-muted) !important;
 }
 
-.delta-filter-badge.neutral {
-    background-color: #e2e3e5;
-    color: #383d41;
+.react-flow__controls-button:hover {
+  background: var(--surface2) !important;
+  fill: var(--text) !important;
 }
 
-.delta-filter-badge.negative {
-    background-color: #f8d7da;
-    color: #721c24;
+.react-flow__minimap {
+  border: 1px solid var(--border) !important;
+  border-radius: 6px !important;
+  box-shadow: 0 4px 16px rgba(0,0,0,.06) !important;
 }
 
-/* Filter button hover effects */
-.button-filter:hover:not(.active) {
-    background: #dee2e6;
+/* ─── BUTTON COMPAT (for modals using old classes) ─── */
+.button {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  transition: all .15s;
 }
 
-/* Animation for active filter changes */
-@keyframes pulse-filter {
-    0% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.05);
-    }
-    100% {
-        transform: scale(1);
-    }
+.button:hover {
+  background: var(--surface2);
+  color: var(--text);
 }
 
-/* Auth panel styles */
-.auth-panel {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid #dee2e6;
-    border-radius: 6px;
-    padding: 8px 12px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(10px);
-    z-index: 20;
-    position: relative;
+.button-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
-.auth-user-info {
-    color: #6c757d;
-    font-size: 12px;
-    font-weight: 500;
+.button-primary:hover {
+  background: var(--accent-hover);
+  color: #fff;
 }
 
-.auth-button {
-    font-size: 12px;
-    padding: 6px 12px;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    background: #fff;
-    color: #495057;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-weight: 500;
+.button-success {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
-.auth-button:hover {
-    background: #f8f9fa;
-    border-color: #adb5bd;
-    transform: translateY(-1px);
+.button-success:hover {
+  background: var(--accent-hover);
+  color: #fff;
 }
 
-.auth-button.logout {
-    background: #dc3545;
-    color: #fff;
-    border-color: #dc3545;
+.button-secondary {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
 }
 
-.auth-button.logout:hover {
-    background: #c82333;
-    border-color: #bd2130;
+.button-secondary:hover {
+  background: var(--surface2);
+  color: var(--text);
 }
 
-.auth-button.signin {
-    background: #007bff;
-    color: #fff;
-    border-color: #007bff;
+.button-info {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
 }
 
-.auth-button.signin:hover {
-    background: #0056b3;
-    border-color: #004085;
+.button-danger {
+  background: var(--red-dim);
+  color: var(--red);
+  border-color: rgba(220, 38, 38, 0.2);
 }
 
-/* Layout inline group to match button row */
-.layout-inline {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px; /* keep same spacing as toolbar buttons */
+.button-danger:hover {
+  background: rgba(220, 38, 38, 0.12);
 }
 
-/* Make <select> look like our secondary button */
-.select-like-btn {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    background: #6c757d url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 20 20" fill="%23ffffff"><path d="M5.25 7.5l4.75 5 4.75-5H5.25z"/></svg>') no-repeat right 8px center;
-    color: #fff;
-    padding: 8px 28px 8px 12px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font: inherit;
-    line-height: 1;
+.button-disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
-.select-like-btn:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba(108,117,125,0.35);
+.button:disabled {
+  opacity: 0.5;
+  cursor: default;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import {
   Background,
   Controls,
   MiniMap,
-  Panel,
   ReactFlow,
   ReactFlowProvider,
 } from '@xyflow/react';
@@ -65,6 +64,7 @@ function applyLockInfo(info: ModelLockInfo): LockState {
 function GraphEditor() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isModelListOpen, setIsModelListOpen] = useState(false);
+  const [tipsOpen, setTipsOpen] = useState(true);
 
   const [auth, setAuth] = useState<{ token: string; user: AuthUser } | null>(() => {
     const token = authStorage.getToken();
@@ -213,20 +213,20 @@ function GraphEditor() {
     await releaseCurrentLock();
   };
 
-  useEffect(() => {
-    if (!(auth || isGuest)) return;
-    if (isLoading) return;
-    if (onboarding.finished) return;
-
-    const id1 = requestAnimationFrame(() => {
-      const id2 = requestAnimationFrame(() => {
-        setTourOpen(true);
-        onboarding.start();
-      });
-      (globalThis as any).__raf2 = id2;
-    });
-    return () => cancelAnimationFrame(id1);
-  }, [auth, isGuest, isLoading, onboarding]);
+  // Onboarding tour auto-start disabled — keep code for manual replay via Help
+  // useEffect(() => {
+  //   if (!(auth || isGuest)) return;
+  //   if (isLoading) return;
+  //   if (onboarding.finished) return;
+  //   const id1 = requestAnimationFrame(() => {
+  //     const id2 = requestAnimationFrame(() => {
+  //       setTourOpen(true);
+  //       onboarding.start();
+  //     });
+  //     (globalThis as any).__raf2 = id2;
+  //   });
+  //   return () => cancelAnimationFrame(id1);
+  // }, [auth, isGuest, isLoading, onboarding]);
 
   useEffect(() => {
     if (!auth?.token || !modelName) {
@@ -334,8 +334,30 @@ function GraphEditor() {
   if (isLoading) return <LoadingState />;
   if (error) return <ErrorState message={error} onRetry={() => globalThis.location.reload()} />;
 
+  const plausibleTransitionCount =
+    bmrgData ? bmrgData.transitions.filter((t) => t.time_25 === 1).length : 0;
+
+  // Count states by VAST class for sidebar legend
+  const classCountMap: Record<string, number> = {};
+  if (bmrgData) {
+    for (const s of bmrgData.states) {
+      const cls = s.vast_state?.vast_class || 'Unknown';
+      classCountMap[cls] = (classCountMap[cls] || 0) + 1;
+    }
+  }
+
+  const legendItems = [
+    { cls: 'Class I', label: 'Reference', bg: '#dcfce7', border: '#86efac' },
+    { cls: 'Class II', label: 'Class II', bg: '#ecfccb', border: '#bef264' },
+    { cls: 'Class III', label: 'Class III', bg: '#fef9c3', border: '#fde047' },
+    { cls: 'Class IV', label: 'Class IV', bg: '#fef3c7', border: '#fcd34d' },
+    { cls: 'Class V', label: 'Class V', bg: '#ffedd5', border: '#fdba74' },
+    { cls: 'Class VI', label: 'Class VI', bg: '#fee2e2', border: '#fca5a5' },
+  ];
+
   return (
     <div className="app-container">
+      {/* ─── TOOLBAR ─── */}
       <div data-tour="toolbar">
         <GraphToolbar
           onAddNode={openAddNodeModal}
@@ -382,56 +404,122 @@ function GraphEditor() {
         />
       </div>
 
-      <ReactFlow
-        nodes={nodesWithCallbacks}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        edgeTypes={customEdgeTypes}
-        defaultEdgeOptions={defaultEdgeOptions}
-        onNodesChange={onNodesChange}
-        onEdgesChange={handleEdgesChange}
-        onConnect={onConnect}
-        onEdgeClick={onEdgeClick}
-        onEdgeDoubleClick={onEdgeDoubleClick}
-        edgesFocusable
-        elementsSelectable
-        edgesReconnectable={lockState.canEdit}
-        reconnectRadius={10}
-        fitView
-        fitViewOptions={{ padding: 0.2, includeHiddenNodes: false }}
-        proOptions={{ hideAttribution: true }}
-        minZoom={0.2}
-        maxZoom={2}
-        nodesDraggable={lockState.canEdit}
-        connectOnClick={lockState.canEdit}
-        zoomOnDoubleClick={false}
-        panOnDrag
-        panOnScroll
-        snapToGrid
-        snapGrid={[20, 20]}
-      >
-        <Background />
-        <MiniMap />
-        <Controls />
+      {/* ─── HEADER ─── */}
+      <div className="header-bar">
+        <div className="model-name">{bmrgData?.stm_name || 'STM Creator'}</div>
+        {bmrgData && (
+          <>
+            <div className="meta-pill">
+              <span className="dot dot-green"></span>
+              {bmrgData.states.length} states
+            </div>
+            <div className="meta-pill">
+              <span className="dot dot-amber"></span>
+              {plausibleTransitionCount} / {bmrgData.transitions.length} transitions
+            </div>
+          </>
+        )}
 
-        <Panel
-          position="top-right"
-          style={{ top: 156, right: 8, width: 360, zIndex: 18 }}
-          data-tour="tips"
-        >
-          <TipsPanel />
-        </Panel>
+        {/* Lock status in header */}
+        <div className="meta-pill" style={{ marginLeft: 'auto' }}>
+          <span className="dot" style={{
+            background: lockState.canEdit ? 'var(--accent)' : 'var(--amber)',
+          }} />
+          {lockState.canEdit ? 'Editing' : `Read-only${lockState.holder ? `: ${lockState.holder}` : ''}`}
+        </div>
 
-        <TransitionFilterPanel
-          dataTourId="filters"
-          bmrgData={bmrgData}
-          showSelfTransitions={showSelfTransitions}
-          deltaFilter={deltaFilter}
-          onToggleSelfTransitions={toggleSelfTransitions}
-          onDeltaFilterChange={toggleDeltaFilter}
-          onReset={loadExistingEdges}
-        />
-      </ReactFlow>
+        {/* Auth info in header */}
+        {auth?.user.email && (
+          <div className="meta-pill">
+            {auth.user.email}
+          </div>
+        )}
+      </div>
+
+      {/* ─── WORKSPACE ─── */}
+      <div className="workspace">
+        {/* LEFT SIDEBAR */}
+        <div className="sidebar">
+          <div className="sidebar-section">
+            <div className="sidebar-label">Classes</div>
+            {legendItems.map((item) => (
+              <div className="legend-item" key={item.cls}>
+                <div
+                  className="legend-swatch"
+                  style={{ background: item.bg, border: `1px solid ${item.border}` }}
+                />
+                <span className="legend-text">{item.label}</span>
+                <span className="legend-count">{classCountMap[item.cls] || 0}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="sidebar-divider" />
+
+          {/* Transition Filters in sidebar */}
+          <TransitionFilterPanel
+            bmrgData={bmrgData}
+            showSelfTransitions={showSelfTransitions}
+            deltaFilter={deltaFilter}
+            onToggleSelfTransitions={toggleSelfTransitions}
+            onDeltaFilterChange={toggleDeltaFilter}
+            onReset={loadExistingEdges}
+            inSidebar
+          />
+        </div>
+
+        {/* CANVAS */}
+        <div className="canvas-area">
+          <ReactFlow
+            nodes={nodesWithCallbacks}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={customEdgeTypes}
+            defaultEdgeOptions={defaultEdgeOptions}
+            onNodesChange={onNodesChange}
+            onEdgesChange={handleEdgesChange}
+            onConnect={onConnect}
+            onEdgeClick={onEdgeClick}
+            onEdgeDoubleClick={onEdgeDoubleClick}
+            edgesFocusable
+            elementsSelectable
+            edgesReconnectable={lockState.canEdit}
+            reconnectRadius={10}
+            fitView
+            fitViewOptions={{ padding: 0.2, includeHiddenNodes: false }}
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.2}
+            maxZoom={2}
+            nodesDraggable={lockState.canEdit}
+            connectOnClick={lockState.canEdit}
+            zoomOnDoubleClick={false}
+            panOnDrag
+            panOnScroll
+            snapToGrid
+            snapGrid={[20, 20]}
+          >
+            <Background />
+            <MiniMap />
+            <Controls />
+          </ReactFlow>
+
+          {/* Status bar */}
+          {bmrgData && (
+            <div className="statusbar">
+              <div className="statusbar-dot" />
+              <span>nodes</span> <b>{bmrgData.states.length}</b>
+              <span>transitions</span> <b>{plausibleTransitionCount}</b>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT PANEL (Tips) */}
+        <div className={`right-panel ${tipsOpen ? 'open' : ''}`}>
+          <div className="rp-inner">
+            <TipsPanel onClose={() => setTipsOpen(false)} />
+          </div>
+        </div>
+      </div>
 
       <Tour open={tourOpen} onClose={closeTour} steps={coachSteps} />
 

--- a/src/EdgeStyles.css
+++ b/src/EdgeStyles.css
@@ -1,95 +1,79 @@
 /* Custom styles for edges */
 
 .react-flow__edge-path {
-    stroke-linecap: round;
-    transition: stroke-width 0.2s, stroke 0.2s;
+  stroke-linecap: round;
+  transition: stroke-width 0.2s, stroke 0.2s;
 }
 
 .react-flow__edge-text {
-    font-size: 10px;
-    font-weight: bold;
-    fill: #333;
-    text-shadow: 1px 1px 2px rgba(255, 255, 255, 0.8);
+  font-size: 10px;
+  font-weight: 500;
+  fill: var(--text);
+  font-family: 'DM Mono', monospace;
 }
 
 .react-flow__edge:hover .react-flow__edge-path {
-    stroke-width: 3px;
-    filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.2));
+  stroke-width: 3px;
+  filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.1));
 }
 
 .react-flow__edge.selected .react-flow__edge-path {
-    stroke-width: 3px;
-    filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.4));
+  stroke-width: 3px;
+  filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.15));
 }
 
-/* Custom styles for edge interactions */
+/* Edge interactions */
 .edgebutton-foreignobject {
-    pointer-events: none;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  pointer-events: none;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .edgebutton-foreignobject div {
-    pointer-events: auto;
-    transition: transform 0.2s, box-shadow 0.2s;
+  pointer-events: auto;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .react-flow__edge:hover .edgebutton-foreignobject div {
-    transform: scale(1.1);
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  transform: scale(1.1);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 /* Edge updater (handles) for reconnecting */
 .react-flow__edge-updater {
-    fill: #fff;
-    stroke: #4a90e2;
-    stroke-width: 1.5;
-    cursor: crosshair;
+  fill: var(--surface);
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  cursor: crosshair;
 }
 
 .react-flow__edge-updater:hover {
-    fill: #4a90e2;
-    stroke-width: 2;
+  fill: var(--accent);
+  stroke-width: 2;
 }
 
 /* Feedback for when edge is being updated */
 .react-flow__edge.updating .react-flow__edge-path {
-    stroke-dasharray: 5;
-    animation: dashdraw 0.5s linear infinite;
+  stroke-dasharray: 5;
+  animation: dashdraw 0.5s linear infinite;
 }
 
 @keyframes dashdraw {
-    from {
-        stroke-dashoffset: 10;
-    }
-    to {
-        stroke-dashoffset: 0;
-    }
+  from { stroke-dashoffset: 10; }
+  to { stroke-dashoffset: 0; }
 }
 
 /* Highlight edge updater handles with a glow effect */
 .react-flow__edge.selected .react-flow__edge-updater {
-    fill: #fff;
-    stroke: #4a90e2;
-    filter: drop-shadow(0 0 3px rgba(74, 144, 226, 0.8));
+  fill: var(--surface);
+  stroke: var(--accent);
+  filter: drop-shadow(0 0 3px rgba(22, 163, 74, 0.6));
 }
 
 /* Make edge updater handles more visible */
 .react-flow__edge-updater {
-    r: 5; /* Increase the radius of the updater handle */
-}
-
-/* Tooltip for edge handles */
-.react-flow__edge-updater::after {
-    content: '';
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    background-color: rgba(74, 144, 226, 0.2);
-    border-radius: 50%;
-    transform: translate(-50%, -50%);
-    pointer-events: none;
+  r: 5;
 }

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -52,14 +52,11 @@ export function GraphToolbar({
   edgeCreationMode,
   isSaving,
   showSelfTransitions,
-  bmrgData,
   onOpenHelp,
   userEmail,
   onLogout,
   onSignIn,
   canEdit,
-  lockHolder,
-  lockExpiresAt,
   onAcquireLock,
   onReleaseLock,
   onRefreshLock,
@@ -80,11 +77,10 @@ export function GraphToolbar({
     event.target.value = '';
   };
 
-  const plausibleTransitionCount =
-    bmrgData ? bmrgData.transitions.filter((t) => t.time_25 === 1).length : 0;
-
   return (
-    <div className="controls-toolbar" data-tour="toolbar">
+    <div className="toolbar">
+      <span className="toolbar-logo">STM</span>
+
       <input
         ref={fileInputRef}
         type="file"
@@ -96,26 +92,28 @@ export function GraphToolbar({
       <button
         data-tour="add-node"
         onClick={onAddNode}
-        className="button button-primary"
+        className="tb-btn primary"
         disabled={editDisabled}
-        title={editDisabled ? 'Model is locked by another user' : undefined}
       >
+        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z"/></svg>
         Add Node
       </button>
 
       <button
         data-tour="create-edge"
         onClick={onToggleEdgeCreation}
-        className={`button button-edge-creation ${edgeCreationMode ? 'active' : ''}`}
+        className={`tb-btn ${edgeCreationMode ? 'active' : ''}`}
         disabled={editDisabled}
-        title={editDisabled ? 'Model is locked by another user' : undefined}
       >
-        {edgeCreationMode ? 'Cancel Edge Creation' : 'Create Edge'}
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 8h12M8 2v12"/><circle cx="8" cy="8" r="2"/></svg>
+        {edgeCreationMode ? 'Cancel Edge' : 'Create Edge'}
       </button>
 
-      <button data-tour="load-all-edges" onClick={onLoadEdges} className="button button-secondary">
+      <button data-tour="load-all-edges" onClick={onLoadEdges} className="tb-btn">
         Load All Edges
       </button>
+
+      <div className="tb-sep" />
 
       <button
         data-tour="save-model"
@@ -123,158 +121,122 @@ export function GraphToolbar({
           void onSaveModel().catch(() => undefined);
         }}
         disabled={isSaving || editDisabled}
-        className={`button button-success ${isSaving ? 'button-disabled' : ''}`}
-        title={editDisabled ? 'Model is locked by another user' : undefined}
+        className="tb-btn"
       >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 12V4l4 4 3-3 5 5"/></svg>
         {isSaving ? 'Saving...' : 'Save Model'}
       </button>
-
-      {onOpenModelList && (
-        <button data-tour="open-model" onClick={onOpenModelList} className="button button-secondary">
-          Open Model
-        </button>
-      )}
-
-      {onDeleteModel && (
-        <button
-          onClick={onDeleteModel}
-          className="button button-danger"
-          title="Delete this model (Admin only)"
-          disabled={editDisabled}
-        >
-          Delete Model
-        </button>
-      )}
 
       <button
         data-tour="save-version"
         onClick={onSaveVersion}
-        className="button button-secondary"
+        className="tb-btn"
         disabled={editDisabled}
-        title={editDisabled ? 'Model is locked by another user' : undefined}
       >
         Save Version
       </button>
 
-      <button data-tour="versions" onClick={onOpenVersionManager} className="button button-secondary">
+      <button data-tour="versions" onClick={onOpenVersionManager} className="tb-btn">
         Versions
       </button>
 
-      <button data-tour="help" onClick={onOpenHelp} className="button button-secondary">
-        Help
-      </button>
+      <div className="tb-sep" />
 
       <button
         data-tour="import-eks"
         onClick={handleImportClick}
-        className="button button-secondary"
+        className="tb-btn"
         disabled={editDisabled}
-        title={editDisabled ? 'Model is locked by another user' : undefined}
       >
         Import EKS
       </button>
 
-      <button data-tour="export-eks" onClick={onExportEKS} className="button button-secondary">
+      <button data-tour="export-eks" onClick={onExportEKS} className="tb-btn">
         Export EKS
       </button>
 
       {onApplyLayout && (
-        <div className="layout-inline">
+        <>
           <select
             value={layout}
             onChange={(e) => setLayout(e.target.value as LayoutStrategy)}
-            className="button button-secondary select-like-btn"
-            title="Layout"
+            className="tb-btn"
+            style={{ paddingRight: 24, appearance: 'auto' as any }}
             disabled={editDisabled}
           >
-            <option value="layered">Layered (directed)</option>
+            <option value="layered">Layered</option>
             <option value="grid">Grid</option>
-            <option value="force">Force-directed</option>
-            <option value="heuristic">Heuristic (project)</option>
+            <option value="force">Force</option>
+            <option value="heuristic">Heuristic</option>
           </select>
-
           <button
             data-tour="apply-layout"
             onClick={() => {
               if (layout === 'heuristic') {
                 onRelayout();
-              } else if (onApplyLayout) {
+              } else {
                 void onApplyLayout(layout);
               }
             }}
-            className="button button-secondary"
+            className="tb-btn"
             disabled={editDisabled}
-            title={editDisabled ? 'Model is locked by another user' : undefined}
           >
-            Apply Layout
-          </button>
-        </div>
-      )}
-
-      <div style={{ flex: 1 }} />
-
-      {userEmail ? (
-        <>
-          <span className="info-panel" style={{ padding: '8px 10px' }}>
-            Signed in as {userEmail}
-          </span>
-          <button onClick={onLogout} className="button button-secondary">
-            Logout
-          </button>
-        </>
-      ) : (
-        <>
-          <span className="info-panel" style={{ padding: '8px 10px' }}>
-            Guest mode
-          </span>
-          <button onClick={onSignIn} className="button button-primary">
-            Sign in
+            Re-layout
           </button>
         </>
       )}
 
-      <span className="info-panel" style={{ padding: '8px 10px' }}>
-        {canEdit ? 'Edit lock acquired' : `Read-only${lockHolder ? `: ${lockHolder}` : ''}`}
-        {lockExpiresAt ? ` (expires ${new Date(lockExpiresAt).toLocaleTimeString()})` : ''}
-      </span>
+      <div className="tb-sep" />
 
+      <button
+        onClick={onToggleSelfTransitions}
+        className={`tb-btn ${showSelfTransitions ? 'active' : ''}`}
+      >
+        {showSelfTransitions ? 'Hide Self-Trans' : 'Show Self-Trans'}
+      </button>
+
+      {onOpenModelList && (
+        <button data-tour="open-model" onClick={onOpenModelList} className="tb-btn">
+          Open Model
+        </button>
+      )}
+
+      {onDeleteModel && (
+        <button onClick={onDeleteModel} className="tb-btn" disabled={editDisabled} style={{ color: 'var(--red)' }}>
+          Delete
+        </button>
+      )}
+
+      <div className="tb-spacer" />
+
+      {/* Lock controls */}
       {!canEdit && onAcquireLock && (
-        <button onClick={onAcquireLock} className="button button-primary">
-          Request Edit Lock
+        <button onClick={onAcquireLock} className="tb-btn primary">
+          Request Lock
         </button>
       )}
 
       {canEdit && onRefreshLock && (
-        <button onClick={onRefreshLock} className="button button-secondary">
-          Refresh Lock
-        </button>
+        <button onClick={onRefreshLock} className="tb-btn">Refresh Lock</button>
       )}
 
       {canEdit && onReleaseLock && (
-        <button onClick={onReleaseLock} className="button button-secondary">
-          Release Lock
-        </button>
+        <button onClick={onReleaseLock} className="tb-btn">Release Lock</button>
       )}
 
-      <button
-        onClick={onToggleSelfTransitions}
-        className={`button ${showSelfTransitions ? 'button-info' : 'button-secondary'}`}
-      >
-        {showSelfTransitions ? 'Hide Self Transitions' : 'Show Self Transitions'}
+      <div className="tb-sep" />
+
+      {/* Auth */}
+      {userEmail ? (
+        <button onClick={onLogout} className="tb-btn">Logout</button>
+      ) : (
+        <button onClick={onSignIn} className="tb-btn primary">Sign in</button>
+      )}
+
+      <button data-tour="help" onClick={onOpenHelp} className="tb-btn">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/></svg>
+        Help
       </button>
-
-      {bmrgData && (
-        <div className="info-panel">
-          <strong>{bmrgData.stm_name}</strong>
-          <span className="info-separator">|</span>
-          <span>{bmrgData.states.length} states</span>
-          <span className="info-separator">|</span>
-          <span>
-            {plausibleTransitionCount} plausible transitions
-            <span className="info-text-muted"> (of {bmrgData.transitions.length} total)</span>
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/app/components/TipsPanel.tsx
+++ b/src/app/components/TipsPanel.tsx
@@ -1,36 +1,44 @@
-import { useState } from 'react';
+interface TipsPanelProps {
+  onClose: () => void;
+}
 
-export function TipsPanel() {
-  const [collapsed, setCollapsed] = useState(true);
-
+export function TipsPanel({ onClose }: TipsPanelProps) {
   return (
-    <div className="stm-ext-card tips-panel">
-      {/* Header with collapse toggle */}
-      <div className="stm-ext-header">
-        <div className="stm-ext-title">Tips</div>
-        <button
-          className="stm-ext-btn ghost"
-          onClick={() => setCollapsed((v) => !v)}
-          aria-label={collapsed ? 'Expand tips' : 'Collapse tips'}
-          title={collapsed ? 'Expand' : 'Collapse'}
-        >
-          {collapsed ? '▸' : '▾'}
-        </button>
+    <>
+      <div className="rp-header">
+        <span className="rp-title">Tips</span>
+        <button className="rp-close" onClick={onClose}>×</button>
       </div>
 
-      {/* Body */}
-      {!collapsed && (
-        <div className="tips-body">
-          <p className="tips-item">🎯 Click a node to edit it</p>
-          <p className="tips-item">🧵 Use Create Edge button to connect nodes</p>
-          <p className="tips-item">👆 Click an edge to select it</p>
-          <p className="tips-item">📝 Double-click an edge to edit transition</p>
-          <p className="tips-item">🔁 Drag edge endpoints to reconnect</p>
-          <p className="tips-item">📐 Use Re-layout to optimize layout</p>
-          <p className="tips-item">🔄 Toggle self-transitions visibility</p>
-          <p className="tips-item">⚖️ Filter transitions by delta value</p>
-        </div>
-      )}
-    </div>
+      <div className="tip-card">
+        <div className="tip-head">Nodes</div>
+        <div className="tip-text">Click a node to edit its attributes. Double-click to rename inline.</div>
+      </div>
+
+      <div className="tip-card">
+        <div className="tip-head">Edges</div>
+        <div className="tip-text">Use <kbd>Create Edge</kbd> then click two nodes to connect them.</div>
+      </div>
+
+      <div className="tip-card">
+        <div className="tip-head">Selection</div>
+        <div className="tip-text">Click an edge to select it. Double-click to edit the transition details.</div>
+      </div>
+
+      <div className="tip-card">
+        <div className="tip-head">Condition Bar</div>
+        <div className="tip-text">The bar on each node visualises the midpoint of its condition range.</div>
+      </div>
+
+      <div className="tip-card">
+        <div className="tip-head">Layout</div>
+        <div className="tip-text">Use <kbd>Re-layout</kbd> to automatically optimize node positions.</div>
+      </div>
+
+      <div className="tip-card">
+        <div className="tip-head">Filter</div>
+        <div className="tip-text">Use the sidebar filters to show only specific transition types.</div>
+      </div>
+    </>
   );
 }

--- a/src/extensions/TransitionFilterPanel.tsx
+++ b/src/extensions/TransitionFilterPanel.tsx
@@ -1,28 +1,19 @@
 // src/extensions/TransitionFilterPanel.tsx
 import { useEffect, useMemo, useState } from 'react';
-import { Panel } from '@xyflow/react';
 import type { BMRGData } from '../utils/stateTransition';
 import type { DeltaFilterOption } from '../app/types';
 
 type Props = {
-  dataTourId?: string;
   bmrgData: BMRGData | null;
-
-  // Global filters from the toolbar (we keep intersecting with them)
   showSelfTransitions: boolean;
   deltaFilter: DeltaFilterOption;
-
-  // We will call this when user changes delta in this panel (keeps toolbar in sync)
   onDeltaFilterChange: (opt: DeltaFilterOption) => void;
-
-  // Kept for compatibility; not rendered here (toggle still lives in toolbar)
   onToggleSelfTransitions: () => void;
-
-  // Called when user clicks "Clear" to restore defaults / redraw edges if needed
   onReset: () => void;
+  /** When true, renders inline for sidebar (no Panel wrapper) */
+  inSidebar?: boolean;
 };
 
-// Robust truthy for 0/1/true/false/"1"/"true"/"yes"
 function isTruthy(v: unknown): boolean {
   if (typeof v === 'boolean') return v;
   if (typeof v === 'number') return v !== 0;
@@ -34,45 +25,35 @@ function isTruthy(v: unknown): boolean {
 }
 
 export function TransitionFilterPanel({
-  dataTourId,
   bmrgData,
   showSelfTransitions,
   deltaFilter,
   onDeltaFilterChange,
-  onToggleSelfTransitions: _onToggleSelfTransitions, // not rendered
+  onToggleSelfTransitions: _onToggleSelfTransitions,
   onReset,
+  inSidebar = false,
 }: Props) {
-  // Default collapsed so it doesn't clutter the canvas
-  const [collapsed, setCollapsed] = useState(true);
-
-  // Local-only filters
+  const [collapsed, setCollapsed] = useState(!inSidebar);
   const [requireTime25, setRequireTime25] = useState(false);
   const [requireTime100, setRequireTime100] = useState(false);
   const [probMin, setProbMin] = useState<number>(0);
   const [probMax, setProbMax] = useState<number>(1);
-  // 'any' => either L25 or L100 in range; 'both' => both in range
   const [rangeMode, setRangeMode] = useState<'any' | 'both'>('any');
 
-  // Probability filter becomes active only when user changes min/max
   const probActive = probMin !== 0 || probMax !== 1;
 
-  // Compute visible ids after ALL filters (toolbar delta/self ∩ local)
   const { visibleIds, matchCount } = useMemo(() => {
     const ids = new Set<number>();
     let count = 0;
     if (!bmrgData) return { visibleIds: ids, matchCount: 0 };
 
     for (const t of bmrgData.transitions) {
-      // 1) Delta (global)
       if (deltaFilter === 'positive' && !(t.transition_delta > 0)) continue;
       if (deltaFilter === 'neutral'  && !(t.transition_delta === 0)) continue;
       if (deltaFilter === 'negative' && !(t.transition_delta < 0)) continue;
-      // 2) Self transitions (global)
       if (!showSelfTransitions && t.start_state_id === t.end_state_id) continue;
-      // 3) Local time flags
       if (requireTime25  && !isTruthy(t.time_25))  continue;
       if (requireTime100 && !isTruthy(t.time_100)) continue;
-      // 4) Local probability range (only if user actually adjusted it)
       if (probActive) {
         const l25  = typeof t.likelihood_25  === 'number' ? t.likelihood_25  : NaN;
         const l100 = typeof t.likelihood_100 === 'number' ? t.likelihood_100 : NaN;
@@ -86,18 +67,10 @@ export function TransitionFilterPanel({
     }
     return { visibleIds: ids, matchCount: count };
   }, [
-    bmrgData,
-    showSelfTransitions,
-    deltaFilter,
-    requireTime25,
-    requireTime100,
-    probMin,
-    probMax,
-    rangeMode,
-    probActive,
+    bmrgData, showSelfTransitions, deltaFilter,
+    requireTime25, requireTime100, probMin, probMax, rangeMode, probActive,
   ]);
 
-  // Apply DOM show/hide (non-invasive to store)
   useEffect(() => {
     const hasLocal = requireTime25 || requireTime100 || probActive;
     const allEdges = Array.from(
@@ -106,12 +79,10 @@ export function TransitionFilterPanel({
     if (!allEdges.length) return;
 
     if (!hasLocal) {
-      // No local filters -> restore visibility (respecting whatever toolbar already did)
       allEdges.forEach((el) => (el.style.display = ''));
       return;
     }
 
-    // Explicitly allow empty matches to hide everything
     allEdges.forEach((el) => {
       const idAttr = el.getAttribute('data-id') || '';
       const m = idAttr.match(/transition-(\d+)/);
@@ -121,7 +92,6 @@ export function TransitionFilterPanel({
     });
   }, [visibleIds, requireTime25, requireTime100, probActive]);
 
-  // Reset local filters & restore visibility
   const clearFilters = () => {
     setRequireTime25(false);
     setRequireTime100(false);
@@ -134,113 +104,113 @@ export function TransitionFilterPanel({
     onReset();
   };
 
-  return (
-    <Panel
-      position="top-left"
-      className="stm-ext-panel"
-      style={{ top: 76, left: 8, width: 380 }}
-      data-tour={dataTourId || "filters"}
-    >
-      <div className="stm-ext-card">
-        <div className="stm-ext-header">
-          <div className="stm-ext-title">
-            Transition Filters
-            <span style={{ marginLeft: 8, fontWeight: 600, fontSize: 11, color: '#6b7280' }}>
-              {`(Matches: ${matchCount})`}
-            </span>
-          </div>
-          <button
-            className="stm-ext-btn ghost"
-            onClick={() => setCollapsed((v) => !v)}
-            aria-label={collapsed ? 'Expand filters' : 'Collapse filters'}
-            title={collapsed ? 'Expand' : 'Collapse'}
-          >
-            {collapsed ? '▸' : '▾'}
-          </button>
+  const content = (
+    <div className="stm-ext-card">
+      <div className="stm-ext-header">
+        <div className="stm-ext-title">
+          Transition Filters
+          <span style={{ marginLeft: 8, fontWeight: 600, fontSize: 10, color: 'var(--text-dim)', fontFamily: "'DM Mono', monospace" }}>
+            ({matchCount})
+          </span>
         </div>
-
-        {!collapsed && (
-          <>
-            {/* Delta selector integrated here (keeps toolbar in sync) */}
-            <div className="stm-ext-row" style={{ gap: 8, flexWrap: 'wrap' }}>
-              <label className="stm-ext-field">
-                <span>Δ filter</span>
-                <select
-                  value={deltaFilter}
-                  onChange={(e) => onDeltaFilterChange(e.target.value as DeltaFilterOption)}
-                >
-                  <option value="all">All</option>
-                  <option value="positive">Positive</option>
-                  <option value="neutral">Neutral</option>
-                  <option value="negative">Negative</option>
-                </select>
-              </label>
-            </div>
-
-            <div className="stm-ext-row">
-              <label className="stm-ext-field">
-                <input
-                  type="checkbox"
-                  checked={requireTime25}
-                  onChange={(e) => setRequireTime25(e.target.checked)}
-                />
-                <span>time_25 = true</span>
-              </label>
-              <label className="stm-ext-field">
-                <input
-                  type="checkbox"
-                  checked={requireTime100}
-                  onChange={(e) => setRequireTime100(e.target.checked)}
-                />
-                <span>time_100 = true</span>
-              </label>
-            </div>
-
-            <div className="stm-ext-row">
-              <label className="stm-ext-field">
-                <span>Probability min</span>
-                <input
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={probMin}
-                  onChange={(e) =>
-                    setProbMin(Math.min(1, Math.max(0, Number(e.target.value) || 0)))
-                  }
-                />
-              </label>
-              <label className="stm-ext-field">
-                <span>Probability max</span>
-                <input
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={probMax}
-                  onChange={(e) =>
-                    setProbMax(Math.min(1, Math.max(0, Number(e.target.value) || 0)))
-                  }
-                />
-              </label>
-            </div>
-
-            <div className="stm-ext-row">
-              <label className="stm-ext-field">
-                <span>Range mode</span>
-                <select value={rangeMode} onChange={(e) => setRangeMode(e.target.value as any)}>
-                  <option value="any">Either in range</option>
-                  <option value="both">Both in range</option>
-                </select>
-              </label>
-            </div>
-
-            <div className="stm-ext-actions">
-              <button className="stm-ext-btn" onClick={clearFilters}>Clear</button>
-            </div>
-          </>
-        )}
+        <button
+          className="stm-ext-btn ghost"
+          onClick={() => setCollapsed((v) => !v)}
+          aria-label={collapsed ? 'Expand filters' : 'Collapse filters'}
+          title={collapsed ? 'Expand' : 'Collapse'}
+        >
+          {collapsed ? '▸' : '▾'}
+        </button>
       </div>
-    </Panel>
+
+      {!collapsed && (
+        <>
+          <div className="stm-ext-row" style={{ gap: 8, flexWrap: 'wrap' }}>
+            <label className="stm-ext-field">
+              <span>Δ filter</span>
+              <select
+                value={deltaFilter}
+                onChange={(e) => onDeltaFilterChange(e.target.value as DeltaFilterOption)}
+              >
+                <option value="all">All</option>
+                <option value="positive">Positive</option>
+                <option value="neutral">Neutral</option>
+                <option value="negative">Negative</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="stm-ext-row">
+            <label className="stm-ext-field">
+              <input
+                type="checkbox"
+                checked={requireTime25}
+                onChange={(e) => setRequireTime25(e.target.checked)}
+              />
+              <span>time_25 = true</span>
+            </label>
+            <label className="stm-ext-field">
+              <input
+                type="checkbox"
+                checked={requireTime100}
+                onChange={(e) => setRequireTime100(e.target.checked)}
+              />
+              <span>time_100 = true</span>
+            </label>
+          </div>
+
+          <div className="stm-ext-row">
+            <label className="stm-ext-field">
+              <span>Prob min</span>
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={probMin}
+                onChange={(e) =>
+                  setProbMin(Math.min(1, Math.max(0, Number(e.target.value) || 0)))
+                }
+              />
+            </label>
+            <label className="stm-ext-field">
+              <span>Prob max</span>
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={probMax}
+                onChange={(e) =>
+                  setProbMax(Math.min(1, Math.max(0, Number(e.target.value) || 0)))
+                }
+              />
+            </label>
+          </div>
+
+          <div className="stm-ext-row">
+            <label className="stm-ext-field">
+              <span>Range</span>
+              <select value={rangeMode} onChange={(e) => setRangeMode(e.target.value as 'any' | 'both')}>
+                <option value="any">Either in range</option>
+                <option value="both">Both in range</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="stm-ext-actions">
+            <button className="stm-ext-btn" onClick={clearFilters}>Clear</button>
+          </div>
+        </>
+      )}
+    </div>
   );
+
+  // When in sidebar, render inline without Panel wrapper
+  if (inSidebar) {
+    return content;
+  }
+
+  // Fallback: render as floating panel (not used in new layout but kept for compat)
+  return content;
 }

--- a/src/extensions/extensions.css
+++ b/src/extensions/extensions.css
@@ -1,21 +1,33 @@
-/* === STM Extensions (panels, buttons) === */
+/* ─── EXTENSION PANEL ─── */
 .stm-ext-panel {
   z-index: 20;
 }
 
 .stm-ext-card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--node-r);
   padding: 10px 12px;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
-  min-width: 280px;
+  box-shadow: 0 4px 14px rgba(0,0,0,.04);
+  min-width: 200px;
+}
+
+/* When inside sidebar, no card border/shadow needed */
+.sidebar .stm-ext-card {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0 14px 10px;
+  box-shadow: none;
+  min-width: auto;
 }
 
 .stm-ext-title {
-  font-size: 13px;
-  font-weight: 700;
-  color: #111827;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
   margin-bottom: 8px;
 }
 
@@ -31,15 +43,30 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 .stm-ext-field input[type="number"],
 .stm-ext-field select {
   height: 28px;
   padding: 0 8px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
   border-radius: 6px;
+  background: var(--surface2);
+  color: var(--text);
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+}
+
+.stm-ext-field input[type="number"]:focus,
+.stm-ext-field select:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.stm-ext-field input[type="checkbox"] {
+  accent-color: var(--accent);
 }
 
 .stm-ext-actions {
@@ -50,18 +77,30 @@
 }
 
 .stm-ext-btn {
-  border: 1px solid #d1d5db;
-  background: #f9fafb;
+  border: 1px solid var(--border);
+  background: var(--surface2);
   border-radius: 6px;
   padding: 4px 10px;
-  font-size: 12px;
+  font-size: 11px;
   cursor: pointer;
+  color: var(--text-muted);
+  font-family: inherit;
+  transition: all .15s;
+}
+
+.stm-ext-btn:hover {
+  background: var(--border);
+  color: var(--text);
 }
 
 .stm-ext-btn.primary {
-  background: #2563eb;
-  border-color: #1d4ed8;
+  background: var(--accent);
+  border-color: var(--accent);
   color: #fff;
+}
+
+.stm-ext-btn.primary:hover {
+  background: var(--accent-hover);
 }
 
 /* header with collapse button */
@@ -81,26 +120,27 @@
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
-}
-.stm-ext-btn.ghost:hover {
-  background: #f3f4f6;
+  color: var(--text-dim);
 }
 
-/* disable interactions when no transition is selected */
+.stm-ext-btn.ghost:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+
+/* disabled state */
 .stm-ext-card.is-disabled {
   opacity: 0.85;
 }
+
 .stm-ext-card.is-disabled input,
 .stm-ext-card.is-disabled select,
 .stm-ext-card.is-disabled button.primary {
   pointer-events: none;
 }
 
-
-
 /* === Product Tour (Scheme A: backdrop + light highlight) === */
 
-/* Backdrop dims the whole page and blocks interactions */
 .tour-backdrop {
   position: fixed;
   inset: 0;
@@ -109,72 +149,74 @@
   z-index: 9998;
 }
 
-/* Highlight rectangle around the target (no giant outer shadow) */
 .tour-highlight {
   position: fixed;
   border-radius: 10px;
-  border: 2px solid #4f46e5; /* indigo */
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35); /* subtle glow */
+  border: 2px solid var(--accent);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
   pointer-events: none;
   z-index: 9999;
 }
 
-/* Tooltip card shown near the target */
 .tour-tooltip {
   position: fixed;
-  background: #fff;
-  color: #111827;
+  background: var(--surface);
+  color: var(--text);
   border-radius: 12px;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
   padding: 14px 16px 12px;
-  z-index: 10000; /* above highlight */
+  z-index: 10000;
   max-width: 360px;
+  border: 1px solid var(--border);
 }
 
-/* Title & body */
 .tour-title {
   font-weight: 700;
-  font-size: 15px;
+  font-size: 14px;
   margin-bottom: 6px;
+  color: var(--text);
 }
 
 .tour-body {
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.45;
-  color: #374151;
+  color: var(--text-muted);
 }
 
-/* Small arrow indicating tooltip direction */
 .tour-tooltip .tour-arrow {
   position: absolute;
   width: 12px;
   height: 12px;
-  background: #fff;
+  background: var(--surface);
   transform: rotate(45deg);
+  border: 1px solid var(--border);
 }
 
 .tour-top .tour-arrow {
   bottom: -6px;
   left: 24px;
-  box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.1);
+  border-top: none;
+  border-left: none;
 }
 .tour-bottom .tour-arrow {
   top: -6px;
   left: 24px;
-  box-shadow: -2px -2px 6px rgba(0, 0, 0, 0.1);
+  border-bottom: none;
+  border-right: none;
 }
 .tour-left .tour-arrow {
   right: -6px;
   top: 24px;
-  box-shadow: 2px -2px 6px rgba(0, 0, 0, 0.1);
+  border-top: none;
+  border-left: none;
 }
 .tour-right .tour-arrow {
   left: -6px;
   top: 24px;
-  box-shadow: -2px 2px 6px rgba(0, 0, 0, 0.1);
+  border-bottom: none;
+  border-right: none;
 }
 
-/* Action row */
 .tour-actions {
   display: flex;
   align-items: center;
@@ -184,8 +226,9 @@
 
 .tour-progress {
   margin-left: auto;
-  font-size: 12px;
-  color: #6b7280;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: 'DM Mono', monospace;
 }
 
 .tour-nav {
@@ -193,26 +236,41 @@
   gap: 8px;
 }
 
-/* Buttons */
 .tour-btn {
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid #e5e7eb;
-  background: #fff;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface);
   cursor: pointer;
-  font-size: 12px;
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-muted);
+  transition: all 0.15s;
+}
+
+.tour-btn:hover {
+  background: var(--surface2);
+  color: var(--text);
 }
 
 .tour-btn.primary {
-  background: #4f46e5;
+  background: var(--accent);
   color: #fff;
-  border-color: #4f46e5;
+  border-color: var(--accent);
+}
+
+.tour-btn.primary:hover {
+  background: var(--accent-hover, #15803d);
 }
 
 .tour-btn.ghost {
   background: transparent;
   border: none;
-  color: #6b7280;
+  color: var(--text-dim);
+}
+
+.tour-btn.ghost:hover {
+  color: var(--text-muted);
 }
 
 .tour-btn:disabled {

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,33 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600;700&family=DM+Mono:wght@400;500&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; }
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --bg: #f4f5f7;
+  --surface: #ffffff;
+  --surface2: #f0f1f3;
+  --border: #e2e4e9;
+  --border-light: #c8ccd6;
+  --text: #0f1117;
+  --text-muted: #5c6170;
+  --text-dim: #adb3bf;
+  --accent: #16a34a;
+  --accent-hover: #15803d;
+  --accent-dim: rgba(22,163,74,0.08);
+  --amber: #d97706;
+  --amber-dim: rgba(217,119,6,0.08);
+  --red: #dc2626;
+  --red-dim: rgba(220,38,38,0.08);
+  --blue: #2563eb;
+  --blue-dim: rgba(37,99,235,0.08);
+  --node-r: 10px;
+  --toolbar-h: 52px;
+  --header-h: 48px;
+
+  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  color: var(--text);
 }
 
 html,
@@ -9,4 +35,6 @@ body,
 #root {
   height: 100%;
   margin: 0;
+  background: var(--bg);
+  overflow: hidden;
 }

--- a/src/nodes/customNode.css
+++ b/src/nodes/customNode.css
@@ -1,135 +1,192 @@
-/* Node container */
+/* ─── NODE CONTAINER ─── */
 .node-container {
-    padding: 10px;
-    width: 180px;
-    min-height: 80px;
-    background: #fff;
-    border-width: 2px;
-    border-style: solid;
-    border-radius: 5px;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  width: 192px;
+  min-height: 80px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--node-r);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  cursor: grab;
+  transition: box-shadow .2s, border-color .2s, transform .15s;
+  user-select: none;
+  animation: fadeUp .3s ease both;
 }
 
-/* State number badge */
-.state-number-badge {
-    position: absolute;
-    top: -20px;
-    right: -20px;
-    color: white;
-    border-radius: 50%;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 12px;
-    font-weight: bold;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+.node-container:hover {
+  border-color: var(--border-light);
+  box-shadow: 0 0 0 1px var(--border-light), 0 8px 24px rgba(0,0,0,.1);
+  transform: translateY(-1px);
+  z-index: 10 !important;
 }
 
-/* Class label banner */
-.class-label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    color: white;
-    font-size: 10px;
-    padding: 2px 5px;
-    text-align: center;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-    font-weight: bold;
+/* ─── NODE HEADER ─── */
+.node-header {
+  padding: 7px 10px 6px;
+  border-radius: calc(var(--node-r) - 1px) calc(var(--node-r) - 1px) 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-/* State name text */
+.node-class {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  font-family: 'DM Mono', monospace;
+}
+
+.node-id {
+  font-size: 9px;
+  font-family: 'DM Mono', monospace;
+  opacity: .7;
+  font-weight: 500;
+}
+
+/* ─── NODE BODY ─── */
+.node-body {
+  padding: 9px 10px 10px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .state-name {
-    font-weight: bold;
-    text-align: center;
-    padding: 0 5px;
-    font-size: 13px;
-    width: 100%;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    hyphens: auto;
-    line-height: 1.3;
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--text);
+  text-align: left;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
+  margin-bottom: 7px;
 }
 
-/* Condition info */
 .condition-info {
-    margin-top: 8px;
-    font-size: 10px;
-    color: #666;
-    background-color: #f8f9fa;
-    padding: 2px 6px;
-    border-radius: 4px;
-    text-align: center;
-    width: 90%;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+  font-size: 10px;
+  font-family: 'DM Mono', monospace;
+  color: var(--text-muted);
+  margin-bottom: 8px;
 }
 
-/* Label input when editing */
+/* ─── CONDITION BAR ─── */
+.node-bar {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--surface2);
+  overflow: hidden;
+}
+
+.node-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width .3s;
+}
+
+/* ─── LABEL INPUT ─── */
 .label-input {
-    width: 90%;
-    border: none;
-    outline: none;
-    font-size: 14px;
-    text-align: center;
-    padding: 5px;
+  width: 90%;
+  border: none;
+  outline: none;
+  font-size: 11.5px;
+  font-family: inherit;
+  padding: 5px;
+  background: var(--surface2);
+  border-radius: 4px;
+  color: var(--text);
 }
 
-/* Color definitions for VAST classes */
-.class-color-1 { /* Class I */
-    border-color: #8bc34a;
-}
-.class-color-1-bg {
-    background-color: #8bc34a;
-}
-
-.class-color-2 { /* Class II */
-    border-color: #cddc39;
-}
-.class-color-2-bg {
-    background-color: #cddc39;
-}
-
-.class-color-3 { /* Class III */
-    border-color: #ffeb3b;
-}
-.class-color-3-bg {
-    background-color: #ffeb3b;
+/* ─── STATE NUMBER BADGE ─── */
+.state-number-badge {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  color: white;
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: 'DM Mono', monospace;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  z-index: 5;
 }
 
-.class-color-4 { /* Class IV */
-    border-color: #ffc107;
-}
-.class-color-4-bg {
-    background-color: #ffc107;
+/* ─── CLASS LABEL (old banner — kept for compat) ─── */
+.class-label {
+  display: none;
 }
 
-.class-color-5 { /* Class V */
-    border-color: #ff9800;
+/* ─── CLASS COLOR THEMES (matching tern-canvas) ─── */
+.class-color-1 {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
 }
-.class-color-5-bg {
-    background-color: #ff9800;
-}
+.class-color-1 .node-class { color: #15803d; }
+.class-color-1 .node-bar-fill { background: #16a34a; }
+.class-color-1-bg { background-color: #16a34a; }
 
-.class-color-6 { /* Class VI */
-    border-color: #ff5722;
+.class-color-2 {
+  background: #f7fee7;
+  border-color: #d9f99d;
 }
-.class-color-6-bg {
-    background-color: #ff5722;
+.class-color-2 .node-class { color: #4d7c0f; }
+.class-color-2 .node-bar-fill { background: #65a30d; }
+.class-color-2-bg { background-color: #65a30d; }
+
+.class-color-3 {
+  background: #fefce8;
+  border-color: #fef08a;
 }
+.class-color-3 .node-class { color: #a16207; }
+.class-color-3 .node-bar-fill { background: #ca8a04; }
+.class-color-3-bg { background-color: #ca8a04; }
+
+.class-color-4 {
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+.class-color-4 .node-class { color: #b45309; }
+.class-color-4 .node-bar-fill { background: #d97706; }
+.class-color-4-bg { background-color: #d97706; }
+
+.class-color-5 {
+  background: #fff7ed;
+  border-color: #fed7aa;
+}
+.class-color-5 .node-class { color: #c2410c; }
+.class-color-5 .node-bar-fill { background: #ea580c; }
+.class-color-5-bg { background-color: #ea580c; }
+
+.class-color-6 {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+.class-color-6 .node-class { color: #b91c1c; }
+.class-color-6 .node-bar-fill { background: #dc2626; }
+.class-color-6-bg { background-color: #dc2626; }
 
 .class-color-default {
-    border-color: #9e9e9e;
+  border-color: var(--border);
 }
-.class-color-default-bg {
-    background-color: #9e9e9e;
+.class-color-default .node-class { color: var(--text-muted); }
+.class-color-default .node-bar-fill { background: var(--text-dim); }
+.class-color-default-bg { background-color: #9e9e9e; }
+
+/* ─── HANDLE STYLES ─── */
+.handle {
+  opacity: 0;
+  transition: opacity .15s;
+}
+
+.node-container:hover .handle {
+  opacity: 1;
 }

--- a/src/nodes/customNode.tsx
+++ b/src/nodes/customNode.tsx
@@ -8,7 +8,6 @@ interface CustomNodeProps extends NodeProps {
     data: CustomNodeData;
 }
 
-// Helper function to get class number
 function getVastClassNumber(vastClass: string): number {
     if (vastClass === 'Class I') return 1;
     if (vastClass === 'Class II') return 2;
@@ -16,6 +15,17 @@ function getVastClassNumber(vastClass: string): number {
     if (vastClass === 'Class IV') return 4;
     if (vastClass === 'Class V') return 5;
     if (vastClass === 'Class VI') return 6;
+    return 0;
+}
+
+function getConditionBarWidth(condition: string): number {
+    const regex = /Condition\s*range:\s*([\d.]+)\s*-\s*([\d.]+)/i;
+    const match = regex.exec(condition);
+    if (match) {
+        const lower = parseFloat(match[1]);
+        const upper = parseFloat(match[2]);
+        return Math.round(((lower + upper) / 2) * 100);
+    }
     return 0;
 }
 
@@ -56,18 +66,17 @@ export function CustomNode({ data, id }: CustomNodeProps) {
         }
     };
 
-    // Get the state attributes if available
     const stateNumber = data.attributes?.stateNumber || '';
     const vastClass = data.attributes?.vastClass || '';
     const condition = data.attributes?.condition || '';
-
-    // Check if this node is currently selected during edge creation
     const isSelected = data.isSelected || false;
     const isEdgeCreationMode = data.isEdgeCreationMode || false;
 
-    // Add special styling for selected nodes during edge creation
+    const classNum = getVastClassNumber(vastClass) || 'default';
+    const barWidth = getConditionBarWidth(condition);
+
     const containerStyle = {
-        boxShadow: isSelected ? '0 0 0 4px #007bff, 0 2px 5px rgba(0, 0, 0, 0.1)' : '0 2px 5px rgba(0, 0, 0, 0.1)',
+        boxShadow: isSelected ? '0 0 0 4px #16a34a, 0 2px 5px rgba(0, 0, 0, 0.1)' : undefined,
         cursor: canEdit ? (isEdgeCreationMode ? 'crosshair' : 'pointer') : 'default'
     };
 
@@ -75,224 +84,87 @@ export function CustomNode({ data, id }: CustomNodeProps) {
         <div
             onClick={handleNodeClick}
             onDoubleClick={onNodeDoubleClick}
-            className={`node-container class-color-${getVastClassNumber(vastClass) || 'default'}`}
+            className={`node-container class-color-${classNum}`}
             style={containerStyle}
         >
             {isEditing ? (
-                <input
-                    type="text"
-                    value={nodeLabel}
-                    onChange={handleInputChange}
-                    onBlur={saveLabel}
-                    onKeyDown={handleKeyDown}
-                    autoFocus
-                    className="label-input"
-                    onClick={e => e.stopPropagation()}
-                />
+                <div className="node-body">
+                    <input
+                        type="text"
+                        value={nodeLabel}
+                        onChange={handleInputChange}
+                        onBlur={saveLabel}
+                        onKeyDown={handleKeyDown}
+                        autoFocus
+                        className="label-input"
+                        onClick={e => e.stopPropagation()}
+                    />
+                </div>
             ) : (
                 <>
-                    {/* State number badge */}
                     {stateNumber && (
-                        <div className={`state-number-badge class-color-${getVastClassNumber(vastClass) || 'default'}-bg`}>
+                        <div className={`state-number-badge class-color-${classNum}-bg`}>
                             {stateNumber}
                         </div>
                     )}
 
-                    {/* Top bar with VAST class */}
-                    {vastClass && (
-                        <div className={`class-label class-color-${getVastClassNumber(vastClass) || 'default'}-bg`}>
-                            {vastClass}
-                        </div>
-                    )}
-
-                    {/* State name with text wrapping */}
-                    <div className="state-name" style={{ marginTop: vastClass ? '15px' : '0' }}>
-                        {data.label}
+                    <div className="node-header">
+                        <span className="node-class">
+                            {vastClass || 'State'}
+                        </span>
+                        <span className="node-id">#{stateNumber || id}</span>
                     </div>
 
-                    {/* Condition info */}
-                    {condition && (
-                        <div className="condition-info">
-                            {condition}
+                    <div className="node-body">
+                        <div className="state-name">
+                            {data.label}
                         </div>
-                    )}
+
+                        {condition && (
+                            <div className="condition-info">
+                                {condition}
+                            </div>
+                        )}
+
+                        {barWidth > 0 && (
+                            <div className="node-bar">
+                                <div className="node-bar-fill" style={{ width: `${barWidth}%` }} />
+                            </div>
+                        )}
+                    </div>
                 </>
             )}
 
-            {/*
-                Multiple connection handles around the node
-                This gives users more options for connecting edges
-                Each handle has a unique ID and position
-            */}
-
             {/* Top edge handles */}
-            <Handle
-                type="source"
-                position={Position.Top}
-                id="top-center-source"
-                style={{ left: '50%' }}
-                className="handle handle-top"
-            />
-            <Handle
-                type="target"
-                position={Position.Top}
-                id="top-center-target"
-                style={{ left: '50%' }}
-                className="handle handle-top"
-            />
-            <Handle
-                type="source"
-                position={Position.Top}
-                id="top-left-source"
-                style={{ left: '25%' }}
-                className="handle handle-top"
-            />
-            <Handle
-                type="target"
-                position={Position.Top}
-                id="top-left-target"
-                style={{ left: '25%' }}
-                className="handle handle-top"
-            />
-            <Handle
-                type="source"
-                position={Position.Top}
-                id="top-right-source"
-                style={{ left: '75%' }}
-                className="handle handle-top"
-            />
-            <Handle
-                type="target"
-                position={Position.Top}
-                id="top-right-target"
-                style={{ left: '75%' }}
-                className="handle handle-top"
-            />
+            <Handle type="source" position={Position.Top} id="top-center-source" style={{ left: '50%' }} className="handle handle-top" />
+            <Handle type="target" position={Position.Top} id="top-center-target" style={{ left: '50%' }} className="handle handle-top" />
+            <Handle type="source" position={Position.Top} id="top-left-source" style={{ left: '25%' }} className="handle handle-top" />
+            <Handle type="target" position={Position.Top} id="top-left-target" style={{ left: '25%' }} className="handle handle-top" />
+            <Handle type="source" position={Position.Top} id="top-right-source" style={{ left: '75%' }} className="handle handle-top" />
+            <Handle type="target" position={Position.Top} id="top-right-target" style={{ left: '75%' }} className="handle handle-top" />
 
             {/* Right edge handles */}
-            <Handle
-                type="source"
-                position={Position.Right}
-                id="right-center-source"
-                style={{ top: '50%' }}
-                className="handle handle-right"
-            />
-            <Handle
-                type="target"
-                position={Position.Right}
-                id="right-center-target"
-                style={{ top: '50%' }}
-                className="handle handle-right"
-            />
-            <Handle
-                type="target"
-                position={Position.Right}
-                id="right-top-target"
-                style={{ top: '25%' }}
-                className="handle handle-right"
-            />
-            <Handle
-                type="source"
-                position={Position.Right}
-                id="right-bottom-source"
-                style={{ top: '75%' }}
-                className="handle handle-right"
-            />
-            <Handle
-                type="target"
-                position={Position.Right}
-                id="right-bottom-target"
-                style={{ top: '75%' }}
-                className="handle handle-right"
-            />
+            <Handle type="source" position={Position.Right} id="right-center-source" style={{ top: '50%' }} className="handle handle-right" />
+            <Handle type="target" position={Position.Right} id="right-center-target" style={{ top: '50%' }} className="handle handle-right" />
+            <Handle type="target" position={Position.Right} id="right-top-target" style={{ top: '25%' }} className="handle handle-right" />
+            <Handle type="source" position={Position.Right} id="right-bottom-source" style={{ top: '75%' }} className="handle handle-right" />
+            <Handle type="target" position={Position.Right} id="right-bottom-target" style={{ top: '75%' }} className="handle handle-right" />
 
             {/* Bottom edge handles */}
-            <Handle
-                type="source"
-                position={Position.Bottom}
-                id="bottom-center-source"
-                style={{ left: '50%' }}
-                className="handle handle-bottom"
-            />
-            <Handle
-                type="target"
-                position={Position.Bottom}
-                id="bottom-center-target"
-                style={{ left: '50%' }}
-                className="handle handle-bottom"
-            />
-            <Handle
-                type="source"
-                position={Position.Bottom}
-                id="bottom-left-source"
-                style={{ left: '25%' }}
-                className="handle handle-bottom"
-            />
-            <Handle
-                type="target"
-                position={Position.Bottom}
-                id="bottom-left-target"
-                style={{ left: '25%' }}
-                className="handle handle-bottom"
-            />
-            <Handle
-                type="source"
-                position={Position.Bottom}
-                id="bottom-right-source"
-                style={{ left: '75%' }}
-                className="handle handle-bottom"
-            />
-            <Handle
-                type="target"
-                position={Position.Bottom}
-                id="bottom-right-target"
-                style={{ left: '75%' }}
-                className="handle handle-bottom"
-            />
+            <Handle type="source" position={Position.Bottom} id="bottom-center-source" style={{ left: '50%' }} className="handle handle-bottom" />
+            <Handle type="target" position={Position.Bottom} id="bottom-center-target" style={{ left: '50%' }} className="handle handle-bottom" />
+            <Handle type="source" position={Position.Bottom} id="bottom-left-source" style={{ left: '25%' }} className="handle handle-bottom" />
+            <Handle type="target" position={Position.Bottom} id="bottom-left-target" style={{ left: '25%' }} className="handle handle-bottom" />
+            <Handle type="source" position={Position.Bottom} id="bottom-right-source" style={{ left: '75%' }} className="handle handle-bottom" />
+            <Handle type="target" position={Position.Bottom} id="bottom-right-target" style={{ left: '75%' }} className="handle handle-bottom" />
 
             {/* Left edge handles */}
-            <Handle
-                type="source"
-                position={Position.Left}
-                id="left-center-source"
-                style={{ top: '50%' }}
-                className="handle handle-left"
-            />
-            <Handle
-                type="target"
-                position={Position.Left}
-                id="left-center-target"
-                style={{ top: '50%' }}
-                className="handle handle-left"
-            />
-            <Handle
-                type="source"
-                position={Position.Left}
-                id="left-top-source"
-                style={{ top: '25%' }}
-                className="handle handle-left"
-            />
-            <Handle
-                type="target"
-                position={Position.Left}
-                id="left-top-target"
-                style={{ top: '25%' }}
-                className="handle handle-left"
-            />
-            <Handle
-                type="source"
-                position={Position.Left}
-                id="left-bottom-source"
-                style={{ top: '75%' }}
-                className="handle handle-left"
-            />
-            <Handle
-                type="target"
-                position={Position.Left}
-                id="left-bottom-target"
-                style={{ top: '75%' }}
-                className="handle handle-left"
-            />
+            <Handle type="source" position={Position.Left} id="left-center-source" style={{ top: '50%' }} className="handle handle-left" />
+            <Handle type="target" position={Position.Left} id="left-center-target" style={{ top: '50%' }} className="handle handle-left" />
+            <Handle type="source" position={Position.Left} id="left-top-source" style={{ top: '25%' }} className="handle handle-left" />
+            <Handle type="target" position={Position.Left} id="left-top-target" style={{ top: '25%' }} className="handle handle-left" />
+            <Handle type="source" position={Position.Left} id="left-bottom-source" style={{ top: '75%' }} className="handle handle-left" />
+            <Handle type="target" position={Position.Left} id="left-bottom-target" style={{ top: '75%' }} className="handle handle-left" />
         </div>
     );
 }


### PR DESCRIPTION
- Adopt three-panel layout: left sidebar, center canvas, right tips panel
- New toolbar with STM logo and compact tb-btn button system
- Add header bar with model name, meta pills, and lock status
- Move TransitionFilterPanel inline into sidebar with inSidebar prop
- Redesign node cards: header/body structure, condition bar, state badge
- Update theme: DM Sans/Mono fonts, green accent, VAST class colors
- Disable onboarding tour auto-start (code preserved for manual replay)
- Preserve all existing functionality: auth, locking, modals, editing