### PR TITLE
Add model selection page after login and New Model button in toolbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -377,6 +377,7 @@ function GraphEditor() {
           onLoadEdges={loadExistingEdges}
           onSaveModel={handleSaveModel}
           onOpenModelList={() => setIsModelListOpen(true)}
+          onCreateNewModel={handleCreateNewModel}
           onDeleteModel={handleDeleteModel}
           onApplyLayout={applyLayout}
           onSaveVersion={saveCurrentVersion}

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -10,6 +10,8 @@ interface GraphToolbarProps {
   readonly onLoadEdges: () => void;
   readonly onSaveModel: () => Promise<SaveModelResponse>;
   readonly onOpenModelList?: () => void;
+  /** Callback to create a new model; receives the model name from the modal input */
+  readonly onCreateNewModel?: (modelName: string) => void;
   readonly onDeleteModel?: () => void;
   readonly onSaveVersion: () => void;
   readonly onOpenVersionManager: () => void;
@@ -41,6 +43,7 @@ export function GraphToolbar({
   onLoadEdges,
   onSaveModel,
   onOpenModelList,
+  onCreateNewModel,
   onDeleteModel,
   onRelayout,
   onApplyLayout,
@@ -63,6 +66,10 @@ export function GraphToolbar({
 }: GraphToolbarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [layout, setLayout] = useState<LayoutStrategy>('force');
+  // Controls visibility of the "Create New Model" modal dialog
+  const [showNewModelModal, setShowNewModelModal] = useState(false);
+  // Tracks the model name input inside the new-model modal
+  const [newModelName, setNewModelName] = useState('');
   const editDisabled = !canEdit;
 
   const handleImportClick = () => {
@@ -199,6 +206,97 @@ export function GraphToolbar({
         <button data-tour="open-model" onClick={onOpenModelList} className="tb-btn">
           Open Model
         </button>
+      )}
+
+      {onCreateNewModel && (
+        <button
+          data-tour="new-model"
+          onClick={() => setShowNewModelModal(true)}
+          className="tb-btn"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z"/></svg>
+          New Model
+        </button>
+      )}
+
+      {/* New Model modal — overlay + centred dialog for entering a new model name.
+          Supports Enter to confirm, Escape to cancel, and backdrop click to dismiss. */}
+      {showNewModelModal && onCreateNewModel && (
+        <div
+          style={{
+            position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            display: 'flex', justifyContent: 'center', alignItems: 'center',
+            zIndex: 1200,
+          }}
+          onClick={() => { setShowNewModelModal(false); setNewModelName(''); }}
+        >
+          <div
+            style={{
+              backgroundColor: '#fff', borderRadius: 12, padding: 24,
+              width: 420, maxWidth: '90%',
+              boxShadow: '0 20px 40px rgba(0,0,0,0.15)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ margin: '0 0 16px', fontSize: 18, fontWeight: 600, color: '#064e3b' }}>
+              Create New Model
+            </h3>
+            <label style={{ display: 'block', fontSize: 13, color: '#065f46', marginBottom: 6 }}>
+              Model Name
+            </label>
+            <input
+              type="text"
+              value={newModelName}
+              onChange={(e) => setNewModelName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && newModelName.trim()) {
+                  onCreateNewModel(newModelName.trim());
+                  setNewModelName('');
+                  setShowNewModelModal(false);
+                }
+                if (e.key === 'Escape') {
+                  setNewModelName('');
+                  setShowNewModelModal(false);
+                }
+              }}
+              placeholder="Enter model name…"
+              autoFocus
+              style={{
+                width: '100%', padding: '10px 12px', borderRadius: 8,
+                border: '1px solid #F0D9A6', fontSize: 14, color: '#065f46', outline: 'none',
+              }}
+            />
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 20 }}>
+              <button
+                onClick={() => { setShowNewModelModal(false); setNewModelName(''); }}
+                style={{
+                  padding: '8px 18px', background: '#fff', color: '#065f46',
+                  border: '1px solid #F0D9A6', borderRadius: 8, cursor: 'pointer', fontSize: 14,
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  if (newModelName.trim()) {
+                    onCreateNewModel(newModelName.trim());
+                    setNewModelName('');
+                    setShowNewModelModal(false);
+                  }
+                }}
+                style={{
+                  padding: '8px 18px',
+                  background: 'linear-gradient(135deg, #10b981, #059669)',
+                  color: '#fff', border: 'none', borderRadius: 8,
+                  cursor: 'pointer', fontSize: 14, fontWeight: 600,
+                }}
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {onDeleteModel && (

--- a/src/app/components/ModelSelectionModal.tsx
+++ b/src/app/components/ModelSelectionModal.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from 'react';
 import { API_BASE, getAuthHeader } from '../auth/api';
 
+/**
+ * Props for ModelSelectionModal.
+ * - isOpen: controls modal visibility
+ * - onClose: called when the user dismisses the modal
+ * - onCreateNew: called with the model name when creating a new model
+ * - onLoadExisting: called with the model name when opening an existing model
+ */
 interface Props {
   readonly isOpen: boolean;
   readonly onClose: () => void;
@@ -8,13 +15,35 @@ interface Props {
   readonly onLoadExisting: (modelName: string) => void;
 }
 
+/**
+ * ModelSelectionModal — displayed after login to let the user pick a model.
+ *
+ * Two sections:
+ *   1. Existing Models List — fetched from GET /models/all (same API as
+ *      the toolbar's "Open Model" button in ModelListModal). Clicking a
+ *      model triggers onLoadExisting, which navigates to /editor?model={name}.
+ *   2. Create New Model — text input + "Create" button. Submitting triggers
+ *      onCreateNew, which navigates to /editor?model={name} (the backend
+ *      auto-creates an empty model when the name doesn't exist yet).
+ */
 export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisting }: Props) {
+  // Input value for the "create new model" text field
   const [modelName, setModelName] = useState('');
+  // Validation error for the create-new input
   const [error, setError] = useState<string | null>(null);
+  // List of existing model names returned by the API
   const [models, setModels] = useState<string[]>([]);
+  // Loading state while fetching the model list
   const [listLoading, setListLoading] = useState(false);
+  // Error message if the model list fetch fails
   const [listError, setListError] = useState<string | null>(null);
 
+  /**
+   * Fetch all existing models from the API whenever the modal opens.
+   * Uses the same endpoint (GET /models/all) as ModelListModal in the toolbar.
+   * A cleanup flag (`cancelled`) prevents state updates if the modal closes
+   * before the request completes.
+   */
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
@@ -25,6 +54,7 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
         const res = await fetch(`${API_BASE}/models/all`, {
           headers: { 'Accept': 'application/json', ...getAuthHeader() },
         });
+        // 401/403 means the user lacks Admin privileges to list models
         if (res.status === 401 || res.status === 403) {
           setListError('Requires Admin privileges to list models.');
           setModels([]);
@@ -34,6 +64,7 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
           const txt = await res.text();
           throw new Error(txt || `Failed to fetch models (${res.status})`);
         }
+        // API returns string[] — filter to be safe
         const data = (await res.json()) as unknown;
         const arr = Array.isArray(data) ? data.filter((x) => typeof x === 'string') as string[] : [];
         if (!cancelled) setModels(arr);
@@ -47,6 +78,7 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
     return () => { cancelled = true; };
   }, [isOpen]);
 
+  // Allow dismissing the modal with the Escape key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isOpen) {
@@ -61,6 +93,7 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
     };
   }, [isOpen]);
 
+  /** Validate the input and trigger model creation */
   const handleCreateNew = () => {
     if (!modelName.trim()) {
       setError('Please enter a model name');
@@ -71,6 +104,7 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
     setError(null);
   };
 
+  /** Reset local state and notify parent to close the modal */
   const handleClose = () => {
     setModelName('');
     setError(null);
@@ -80,15 +114,21 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
   if (!isOpen) return null;
 
   return (
+    /* Overlay — clicking the backdrop closes the modal */
     <div style={overlay} onClick={handleClose}>
+      {/* Modal card — stopPropagation prevents backdrop-click from closing */}
       <div style={modal} onClick={(e) => e.stopPropagation()} aria-labelledby="model-selection-title">
-        {/* Header */}
+
+        {/* ── Section 1: Header ── */}
         <div style={header}>
           <h2 id="model-selection-title" style={titleStyle}>Select Model</h2>
           <button onClick={handleClose} style={closeBtn} aria-label="Close">✖</button>
         </div>
 
-        {/* Existing Models List */}
+        {/* ── Section 2: Existing Models List ──
+            Fetched from GET /models/all on mount.
+            Clicking a model item calls onLoadExisting(name), which navigates
+            to /editor?model={name} — same behaviour as the toolbar "Open Model". */}
         <div style={sectionBox}>
           <h3 style={sectionTitle}>Existing Models</h3>
           {listLoading ? (
@@ -126,14 +166,17 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
           )}
         </div>
 
-        {/* Divider */}
+        {/* ── Visual divider between the two sections ── */}
         <div style={divider}>
           <span style={dividerLine} />
           <span style={dividerText}>OR CREATE NEW</span>
           <span style={dividerLine} />
         </div>
 
-        {/* Create New Model */}
+        {/* ── Section 3: Create New Model ──
+            User types a model name and clicks "Create" (or presses Enter).
+            Calls onCreateNew(name), which navigates to /editor?model={name}.
+            The backend auto-creates an empty model when the name doesn't exist. */}
         <div style={createSection}>
           <div style={createRow}>
             <input
@@ -155,8 +198,11 @@ export function ModelSelectionModal({ isOpen, onClose, onCreateNew, onLoadExisti
   );
 }
 
-/* ── Styles ── */
+/* ── Inline Styles ──
+   All styles use React.CSSProperties objects to keep the component self-contained.
+   The colour palette matches the project's green/gold theme used in AuthPage. */
 
+/** Full-screen semi-transparent backdrop */
 const overlay: React.CSSProperties = {
   position: 'fixed',
   top: 0, left: 0, right: 0, bottom: 0,
@@ -167,6 +213,7 @@ const overlay: React.CSSProperties = {
   zIndex: 1200,
 };
 
+/** Centred modal card with vertical flex layout */
 const modal: React.CSSProperties = {
   backgroundColor: '#fff',
   borderRadius: 16,
@@ -202,6 +249,7 @@ const closeBtn: React.CSSProperties = {
   padding: 4,
 };
 
+/** Scrollable container for the existing models list */
 const sectionBox: React.CSSProperties = {
   flex: 1,
   minHeight: 0,
@@ -232,6 +280,7 @@ const errorBoxStyle: React.CSSProperties = {
   border: '1px solid #fca5a5',
 };
 
+/** Grid layout for model items; max-height with scroll for long lists */
 const listContainer: React.CSSProperties = {
   listStyle: 'none',
   padding: 0,
@@ -242,6 +291,7 @@ const listContainer: React.CSSProperties = {
   overflowY: 'auto',
 };
 
+/** Individual model row button — hover colours are set via JS events */
 const modelItemBtn: React.CSSProperties = {
   width: '100%',
   textAlign: 'left',
@@ -263,6 +313,7 @@ const modelIcon: React.CSSProperties = {
   flexShrink: 0,
 };
 
+/** Horizontal rule with centred "OR CREATE NEW" label */
 const divider: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
@@ -283,6 +334,7 @@ const dividerText: React.CSSProperties = {
   letterSpacing: '1px',
 };
 
+/** Wrapper for the create-new-model input row */
 const createSection: React.CSSProperties = {};
 
 const createRow: React.CSSProperties = {


### PR DESCRIPTION
Summary
Refactor post-login model selection modal (#42): After login, the ModelSelectionModal now fetches and displays a list of all existing models from GET /models/all. Users can click any model to open it (same logic as the toolbar's "Open Model"), or type a new name and click "Create" to start a fresh model.
Add "New Model" button to canvas toolbar (#41): A new "New Model" button is placed next to "Open Model" in GraphToolbar. Clicking it opens a modal dialog to input a model name and create it.