### PR TITLE
Add Milestone panel and Comment panel with @mention support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import { EdgeCreationHint } from './app/components/EdgeCreationHint';
 import { ErrorState } from './app/components/ErrorState';
 import { LoadingState } from './app/components/LoadingState';
 import { TipsPanel } from './app/components/TipsPanel';
-import { VersionManagerModal } from './app/components/VersionManagerModal';
+import { MilestoneModal } from './app/components/MilestoneModal';
 import { ModelListModal } from './app/components/ModelListModal';
 import { HelpModal } from './app/components/HelpModal';
 import { useGraphEditor } from './app/hooks/useGraphEditor';
@@ -380,8 +380,7 @@ function GraphEditor() {
           onCreateNewModel={handleCreateNewModel}
           onDeleteModel={handleDeleteModel}
           onApplyLayout={applyLayout}
-          onSaveVersion={saveCurrentVersion}
-          onOpenVersionManager={openVersionManager}
+          onOpenMilestone={openVersionManager}
           onImportEKS={importFromEKS}
           onExportEKS={exportToEKS}
           onRelayout={handleReLayout}
@@ -561,12 +560,14 @@ function GraphEditor() {
         stateNames={stateNameMap}
       />
 
-      <VersionManagerModal
+      <MilestoneModal
         isOpen={isVersionModalOpen}
         versions={versions}
         onClose={closeVersionManager}
+        onSave={saveCurrentVersion}
         onRestore={restoreVersion}
         onDelete={deleteVersion}
+        canEdit={baseCanEdit}
       />
 
       <HelpModal isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { EdgeCreationHint } from './app/components/EdgeCreationHint';
 import { ErrorState } from './app/components/ErrorState';
 import { LoadingState } from './app/components/LoadingState';
 import { TipsPanel } from './app/components/TipsPanel';
+import { CommentPanel } from './app/components/CommentPanel';
 import { MilestoneModal } from './app/components/MilestoneModal';
 import { ModelListModal } from './app/components/ModelListModal';
 import { HelpModal } from './app/components/HelpModal';
@@ -59,6 +60,7 @@ function GraphEditor() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isModelListOpen, setIsModelListOpen] = useState(false);
   const [tipsOpen, setTipsOpen] = useState(true);
+  const [commentsOpen, setCommentsOpen] = useState(false);
 
   const [auth, setAuth] = useState<{ token: string; user: AuthUser } | null>(() => {
     const token = authStorage.getToken();
@@ -390,6 +392,7 @@ function GraphEditor() {
           showSelfTransitions={showSelfTransitions}
           bmrgData={bmrgData}
           onOpenHelp={() => setIsHelpOpen(true)}
+          onToggleComments={() => setCommentsOpen(prev => !prev)}
           userEmail={auth?.user.email ?? null}
           isGuest={isGuest}
           canEdit={baseCanEdit}
@@ -516,10 +519,28 @@ function GraphEditor() {
           )}
         </div>
 
-        {/* RIGHT PANEL (Tips) */}
-        <div className={`right-panel ${tipsOpen ? 'open' : ''}`}>
+        {/* RIGHT PANEL — Tips or Comments */}
+        <div className={`right-panel ${tipsOpen || commentsOpen ? 'open' : ''}`}>
           <div className="rp-inner">
-            <TipsPanel onClose={() => setTipsOpen(false)} />
+            {commentsOpen ? (
+              <CommentPanel
+                onClose={() => setCommentsOpen(false)}
+                nodes={nodesWithCallbacks.map(n => ({ id: n.id, label: (n.data as any).label || n.id }))}
+                edges={edges.map(e => {
+                  const srcNode = nodesWithCallbacks.find(n => n.id === e.source);
+                  const tgtNode = nodesWithCallbacks.find(n => n.id === e.target);
+                  return {
+                    id: e.id,
+                    sourceLabel: (srcNode?.data as any)?.label || e.source,
+                    targetLabel: (tgtNode?.data as any)?.label || e.target,
+                  };
+                })}
+                userEmail={auth?.user.email || 'Guest'}
+                modelName={modelName || 'unnamed'}
+              />
+            ) : tipsOpen ? (
+              <TipsPanel onClose={() => setTipsOpen(false)} />
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/app/components/CommentPanel.tsx
+++ b/src/app/components/CommentPanel.tsx
@@ -1,0 +1,419 @@
+import { useState, useRef, useEffect } from 'react';
+
+/** A single comment entry */
+export interface CommentEntry {
+    id: string;
+    text: string;
+    author: string;
+    createdAt: string;
+}
+
+/** An @-mentionable item (node or edge) */
+interface MentionItem {
+    type: 'node' | 'edge';
+    id: string;
+    label: string;
+}
+
+interface CommentPanelProps {
+    onClose: () => void;
+    /** Available nodes: { id, label } */
+    nodes: { id: string; label: string }[];
+    /** Available edges: { id, sourceLabel, targetLabel } */
+    edges: { id: string; sourceLabel: string; targetLabel: string }[];
+    /** Current user email for authorship */
+    userEmail: string;
+    /** Model name used as localStorage key */
+    modelName: string;
+}
+
+// localStorage helpers
+function loadComments(modelName: string): CommentEntry[] {
+    try {
+        const raw = localStorage.getItem(`stmCreator.comments.${modelName}`);
+        return raw ? (JSON.parse(raw) as CommentEntry[]) : [];
+    } catch { return []; }
+}
+
+function saveComments(modelName: string, comments: CommentEntry[]) {
+    localStorage.setItem(`stmCreator.comments.${modelName}`, JSON.stringify(comments));
+}
+
+export function CommentPanel({ onClose, nodes, edges, userEmail, modelName }: CommentPanelProps) {
+    const [comments, setComments] = useState<CommentEntry[]>(() => loadComments(modelName));
+    const [text, setText] = useState('');
+    const [showMentions, setShowMentions] = useState(false);
+    const [mentionFilter, setMentionFilter] = useState('');
+    const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // Reload comments when model changes
+    useEffect(() => {
+        setComments(loadComments(modelName));
+    }, [modelName]);
+
+    // Build the mention list from nodes and edges
+    const mentionItems: MentionItem[] = [
+        ...nodes.map(n => ({ type: 'node' as const, id: n.id, label: n.label })),
+        ...edges.map(e => ({ type: 'edge' as const, id: e.id, label: `${e.sourceLabel} → ${e.targetLabel}` })),
+    ];
+
+    const filteredMentions = mentionItems.filter(m =>
+        m.label.toLowerCase().includes(mentionFilter.toLowerCase())
+    );
+
+    const handleTextChange = (value: string) => {
+        setText(value);
+        // Detect @ trigger: find the last @ that isn't part of a completed @[...] mention
+        const lastAt = value.lastIndexOf('@');
+        if (lastAt >= 0) {
+            const afterAt = value.slice(lastAt + 1);
+            // If it starts with '[' and has a closing ']', the mention is complete
+            if (afterAt.startsWith('[') && afterAt.includes(']')) {
+                setShowMentions(false);
+                setMentionFilter('');
+                return;
+            }
+            // Show dropdown; strip leading '[' if user hasn't closed bracket yet
+            const filter = afterAt.startsWith('[') ? afterAt.slice(1) : afterAt;
+            // Hide if there's a newline in the filter
+            if (!filter.includes('\n')) {
+                setShowMentions(true);
+                setMentionFilter(filter);
+                return;
+            }
+        }
+        setShowMentions(false);
+        setMentionFilter('');
+    };
+
+    const insertMention = (item: MentionItem) => {
+        const lastAt = text.lastIndexOf('@');
+        const before = text.slice(0, lastAt);
+        const newText = `${before}@[${item.label}] `;
+        setText(newText);
+        setShowMentions(false);
+        setMentionFilter('');
+        textareaRef.current?.focus();
+    };
+
+    const handleSubmit = () => {
+        if (!text.trim()) return;
+        const entry: CommentEntry = {
+            id: `comment-${Date.now()}-${Math.random().toString(16).slice(2, 6)}`,
+            text: text.trim(),
+            author: userEmail || 'Guest',
+            createdAt: new Date().toISOString(),
+        };
+        const next = [entry, ...comments];
+        setComments(next);
+        saveComments(modelName, next);
+        setText('');
+    };
+
+    const confirmDelete = () => {
+        if (!pendingDeleteId) return;
+        const next = comments.filter(c => c.id !== pendingDeleteId);
+        setComments(next);
+        saveComments(modelName, next);
+        setPendingDeleteId(null);
+    };
+
+    /** Render comment text with @[...] mentions highlighted */
+    const renderText = (raw: string) => {
+        // Match @[mention name] format
+        const parts = raw.split(/(@\[[^\]]+\])/g);
+        return parts.map((part, i) =>
+            part.startsWith('@[')
+                ? <span key={i} style={mentionHighlight}>{part}</span>
+                : <span key={i}>{part}</span>
+        );
+    };
+
+    return (
+        <>
+            <div className="rp-header">
+                <span className="rp-title">Comments</span>
+                <button className="rp-close" onClick={onClose}>×</button>
+            </div>
+
+            {/* New comment input */}
+            <div style={inputSection}>
+                <div style={{ position: 'relative' }}>
+                    <textarea
+                        ref={textareaRef}
+                        value={text}
+                        onChange={(e) => handleTextChange(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' && !e.shiftKey && !showMentions) {
+                                e.preventDefault();
+                                handleSubmit();
+                            }
+                        }}
+                        placeholder="Write a comment… Use @ to mention nodes/edges"
+                        style={textareaStyle}
+                        rows={3}
+                    />
+                    {/* @mention dropdown — positioned below textarea using its bounding rect */}
+                    {showMentions && filteredMentions.length > 0 && textareaRef.current && (() => {
+                        const rect = textareaRef.current!.getBoundingClientRect();
+                        return (
+                            <div style={{ ...mentionDropdown, top: rect.bottom + 4, left: rect.left }}>
+                                {filteredMentions.slice(0, 8).map(item => (
+                                    <button
+                                        key={`${item.type}-${item.id}`}
+                                        onClick={() => insertMention(item)}
+                                        style={mentionItem}
+                                        onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--surface2, #f0fdf4)'; }}
+                                        onMouseLeave={(e) => { e.currentTarget.style.background = '#fff'; }}
+                                    >
+                                        <span style={mentionBadge(item.type)}>
+                                            {item.type === 'node' ? 'N' : 'E'}
+                                        </span>
+                                        <span style={{ fontSize: 12 }}>{item.label}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        );
+                    })()}
+                </div>
+                <button onClick={handleSubmit} style={submitBtn} disabled={!text.trim()}>
+                    Submit
+                </button>
+            </div>
+
+            <div style={dividerStyle} />
+
+            {/* Comment history */}
+            <div style={historySection}>
+                {comments.length === 0 ? (
+                    <p style={emptyText}>No comments yet.</p>
+                ) : (
+                    comments.map(c => (
+                        <div key={c.id} style={commentCard}>
+                            <div style={commentHeader}>
+                                <span style={authorStyle}>{c.author}</span>
+                                <span style={dateStyle}>{new Date(c.createdAt).toLocaleString()}</span>
+                            </div>
+                            <div style={commentText}>{renderText(c.text)}</div>
+                            <button
+                                onClick={() => setPendingDeleteId(c.id)}
+                                style={deleteBtnStyle}
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    ))
+                )}
+            </div>
+
+            {/* Delete confirmation overlay */}
+            {pendingDeleteId && (
+                <div style={confirmOverlay}>
+                    <div style={confirmBox}>
+                        <p style={confirmText}>Delete this comment?</p>
+                        <div style={confirmActions}>
+                            <button onClick={() => setPendingDeleteId(null)} style={confirmCancelBtn}>Cancel</button>
+                            <button onClick={confirmDelete} style={confirmDeleteBtn}>Delete</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}
+
+/* ── Styles ── */
+
+const inputSection: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    marginBottom: 12,
+};
+
+const textareaStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '8px 10px',
+    borderRadius: 6,
+    border: '1px solid var(--border, #e5e7eb)',
+    background: 'var(--surface2, #fff)',
+    color: 'var(--text, #064e3b)',
+    fontSize: 12,
+    resize: 'vertical',
+    outline: 'none',
+    fontFamily: 'inherit',
+};
+
+const mentionDropdown: React.CSSProperties = {
+    position: 'fixed',
+    width: 228,
+    maxHeight: 220,
+    overflowY: 'auto',
+    background: '#fff',
+    border: '1px solid var(--border, #e5e7eb)',
+    borderRadius: 6,
+    boxShadow: '0 4px 16px rgba(0,0,0,0.18)',
+    zIndex: 1300,
+};
+
+const mentionItem: React.CSSProperties = {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '6px 10px',
+    border: 'none',
+    background: '#fff',
+    cursor: 'pointer',
+    textAlign: 'left',
+    fontSize: 12,
+};
+
+const mentionBadge = (type: 'node' | 'edge'): React.CSSProperties => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 18,
+    height: 18,
+    borderRadius: 4,
+    fontSize: 10,
+    fontWeight: 700,
+    color: '#fff',
+    background: type === 'node' ? '#10b981' : '#6366f1',
+    flexShrink: 0,
+});
+
+const submitBtn: React.CSSProperties = {
+    padding: '6px 14px',
+    background: 'linear-gradient(135deg, #10b981, #059669)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontSize: 12,
+    fontWeight: 600,
+    alignSelf: 'flex-end',
+};
+
+const dividerStyle: React.CSSProperties = {
+    height: 1,
+    background: 'var(--border, #e5e7eb)',
+    marginBottom: 12,
+};
+
+const historySection: React.CSSProperties = {
+    flex: 1,
+    overflowY: 'auto',
+};
+
+const emptyText: React.CSSProperties = {
+    color: 'var(--text-muted, #6b7280)',
+    fontSize: 12,
+    margin: '8px 0',
+};
+
+const commentCard: React.CSSProperties = {
+    background: 'var(--surface2, #f9fafb)',
+    border: '1px solid var(--border, #e5e7eb)',
+    borderRadius: 8,
+    padding: '10px 12px',
+    marginBottom: 8,
+};
+
+const commentHeader: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+};
+
+const authorStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    color: 'var(--text, #064e3b)',
+};
+
+const dateStyle: React.CSSProperties = {
+    fontSize: 10,
+    color: 'var(--text-muted, #6b7280)',
+};
+
+const commentText: React.CSSProperties = {
+    fontSize: 12,
+    color: 'var(--text, #064e3b)',
+    lineHeight: 1.5,
+    wordBreak: 'break-word',
+    marginBottom: 6,
+};
+
+const mentionHighlight: React.CSSProperties = {
+    color: '#059669',
+    fontWeight: 600,
+    background: 'rgba(16, 185, 129, 0.1)',
+    borderRadius: 3,
+    padding: '0 2px',
+};
+
+const deleteBtnStyle: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    color: '#ef4444',
+    fontSize: 11,
+    cursor: 'pointer',
+    padding: 0,
+    fontWeight: 500,
+};
+
+const confirmOverlay: React.CSSProperties = {
+    position: 'fixed',
+    top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1200,
+};
+
+const confirmBox: React.CSSProperties = {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 20,
+    width: 300,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.2)',
+    textAlign: 'center',
+};
+
+const confirmText: React.CSSProperties = {
+    margin: '0 0 16px',
+    fontSize: 14,
+    color: '#064e3b',
+    fontWeight: 500,
+};
+
+const confirmActions: React.CSSProperties = {
+    display: 'flex',
+    gap: 10,
+    justifyContent: 'center',
+};
+
+const confirmCancelBtn: React.CSSProperties = {
+    padding: '8px 20px',
+    background: '#fff',
+    color: '#065f46',
+    border: '1px solid #F0D9A6',
+    borderRadius: 8,
+    cursor: 'pointer',
+    fontSize: 14,
+};
+
+const confirmDeleteBtn: React.CSSProperties = {
+    padding: '8px 20px',
+    background: '#ef4444',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 8,
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 600,
+};

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -25,6 +25,8 @@ interface GraphToolbarProps {
   readonly showSelfTransitions: boolean;
   readonly bmrgData: BMRGData | null;
   readonly onOpenHelp: () => void;
+  /** Toggle the right-side comment panel */
+  readonly onToggleComments?: () => void;
   readonly userEmail?: string | null;
   readonly isGuest?: boolean;
   readonly onLogout?: () => void;
@@ -55,6 +57,7 @@ export function GraphToolbar({
   isSaving,
   showSelfTransitions,
   onOpenHelp,
+  onToggleComments,
   userEmail,
   onLogout,
   onSignIn,
@@ -325,6 +328,13 @@ export function GraphToolbar({
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5"/></svg>
         Help
       </button>
+
+      {onToggleComments && (
+        <button data-tour="comments" onClick={onToggleComments} className="tb-btn">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 3h12v8H6l-3 2v-2H2z"/></svg>
+          Comment
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/components/GraphToolbar.tsx
+++ b/src/app/components/GraphToolbar.tsx
@@ -13,8 +13,8 @@ interface GraphToolbarProps {
   /** Callback to create a new model; receives the model name from the modal input */
   readonly onCreateNewModel?: (modelName: string) => void;
   readonly onDeleteModel?: () => void;
-  readonly onSaveVersion: () => void;
-  readonly onOpenVersionManager: () => void;
+  /** Opens the unified Milestone modal (save + history) */
+  readonly onOpenMilestone: () => void;
   readonly onImportEKS: (file: File) => void | Promise<void>;
   readonly onExportEKS: () => void;
   readonly onRelayout: () => void;
@@ -47,8 +47,7 @@ export function GraphToolbar({
   onDeleteModel,
   onRelayout,
   onApplyLayout,
-  onSaveVersion,
-  onOpenVersionManager,
+  onOpenMilestone,
   onImportEKS,
   onExportEKS,
   onToggleSelfTransitions,
@@ -134,17 +133,8 @@ export function GraphToolbar({
         {isSaving ? 'Saving...' : 'Save Model'}
       </button>
 
-      <button
-        data-tour="save-version"
-        onClick={onSaveVersion}
-        className="tb-btn"
-        disabled={editDisabled}
-      >
-        Save Version
-      </button>
-
-      <button data-tour="versions" onClick={onOpenVersionManager} className="tb-btn">
-        Versions
+      <button data-tour="milestone" onClick={onOpenMilestone} className="tb-btn">
+        Milestone
       </button>
 
       <div className="tb-sep" />

--- a/src/app/components/MilestoneModal.tsx
+++ b/src/app/components/MilestoneModal.tsx
@@ -1,0 +1,286 @@
+import { useState } from 'react';
+import { GraphModelVersion } from '../types';
+
+interface MilestoneModalProps {
+    isOpen: boolean;
+    versions: GraphModelVersion[];
+    onClose: () => void;
+    /** Save with an optional custom name; if empty, an auto-generated name is used */
+    onSave: (customName?: string) => void;
+    onRestore: (id: string) => void;
+    onDelete: (id: string) => void;
+    canEdit: boolean;
+}
+
+/**
+ * MilestoneModal — unified modal that combines "Save Version" and "Versions"
+ * into a single panel. The top section has an optional name input and a button
+ * to save the current model state as a new milestone; the bottom section lists
+ * all saved milestones with Restore and Delete actions.
+ */
+export function MilestoneModal({
+    isOpen,
+    versions,
+    onClose,
+    onSave,
+    onRestore,
+    onDelete,
+    canEdit,
+}: MilestoneModalProps) {
+    // User-entered name for the milestone (optional)
+    const [milestoneName, setMilestoneName] = useState('');
+
+    if (!isOpen) return null;
+
+    const handleSave = () => {
+        onSave(milestoneName);
+        setMilestoneName('');
+    };
+
+    const handleDelete = (event: React.MouseEvent<HTMLButtonElement>, id: string) => {
+        event.stopPropagation();
+        onDelete(id);
+    };
+
+    return (
+        <div style={overlay} onClick={onClose}>
+            <div style={modal} onClick={(e) => e.stopPropagation()}>
+                {/* Header */}
+                <div style={header}>
+                    <h2 style={titleStyle}>Milestones</h2>
+                    <button onClick={onClose} style={closeBtn} aria-label="Close">✕</button>
+                </div>
+
+                {/* Save current state as milestone — optional name input + save button */}
+                <div style={saveSection}>
+                    <input
+                        type="text"
+                        value={milestoneName}
+                        onChange={(e) => setMilestoneName(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter' && canEdit) handleSave(); }}
+                        placeholder="Milestone name (optional)…"
+                        style={nameInput}
+                    />
+                    <button
+                        onClick={handleSave}
+                        disabled={!canEdit}
+                        style={{
+                            ...saveBtnStyle,
+                            opacity: canEdit ? 1 : 0.5,
+                            cursor: canEdit ? 'pointer' : 'not-allowed',
+                        }}
+                    >
+                        <svg viewBox="0 0 16 16" fill="currentColor" style={{ width: 14, height: 14 }}>
+                            <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z"/>
+                        </svg>
+                        Save Current State as Milestone
+                    </button>
+                </div>
+
+                <div style={divider} />
+
+                {/* Milestone history list */}
+                <div style={listSection}>
+                    <h3 style={sectionTitle}>History</h3>
+                    {versions.length === 0 ? (
+                        <p style={emptyText}>No milestones saved yet.</p>
+                    ) : (
+                        <ul style={listContainer}>
+                            {versions.map((version) => {
+                                const savedAt = new Date(version.savedAt);
+                                return (
+                                    <li key={version.id} style={listItem}>
+                                        <div>
+                                            <div style={versionName}>{version.name}</div>
+                                            <div style={versionDate}>
+                                                {savedAt.toLocaleString()}
+                                            </div>
+                                        </div>
+                                        <div style={actionRow}>
+                                            <button
+                                                onClick={() => onRestore(version.id)}
+                                                style={restoreBtn}
+                                            >
+                                                Restore
+                                            </button>
+                                            <button
+                                                onClick={(e) => handleDelete(e, version.id)}
+                                                style={deleteBtn}
+                                            >
+                                                Delete
+                                            </button>
+                                        </div>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/* ── Styles ── */
+
+const overlay: React.CSSProperties = {
+    position: 'fixed',
+    top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1100,
+};
+
+const modal: React.CSSProperties = {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 24,
+    width: 520,
+    maxWidth: '92%',
+    maxHeight: '80vh',
+    display: 'flex',
+    flexDirection: 'column',
+    boxShadow: '0 20px 40px rgba(0,0,0,0.15)',
+};
+
+const header: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+};
+
+const titleStyle: React.CSSProperties = {
+    margin: 0,
+    fontSize: 20,
+    fontWeight: 600,
+    color: '#064e3b',
+};
+
+const closeBtn: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    fontSize: 18,
+    cursor: 'pointer',
+    color: '#065f46',
+    padding: 4,
+};
+
+const saveSection: React.CSSProperties = {
+    marginBottom: 16,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+};
+
+const nameInput: React.CSSProperties = {
+    width: '100%',
+    padding: '10px 12px',
+    borderRadius: 8,
+    border: '1px solid #F0D9A6',
+    fontSize: 14,
+    color: '#065f46',
+    outline: 'none',
+};
+
+const saveBtnStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '12px 16px',
+    background: 'linear-gradient(135deg, #10b981, #059669)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 8,
+    fontSize: 14,
+    fontWeight: 600,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+};
+
+const divider: React.CSSProperties = {
+    height: 1,
+    background: '#e5e7eb',
+    marginBottom: 16,
+};
+
+const listSection: React.CSSProperties = {
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+};
+
+const sectionTitle: React.CSSProperties = {
+    margin: '0 0 12px 0',
+    fontSize: 13,
+    fontWeight: 600,
+    color: '#065f46',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+};
+
+const emptyText: React.CSSProperties = {
+    color: '#6b7280',
+    fontSize: 14,
+    margin: '8px 0',
+};
+
+const listContainer: React.CSSProperties = {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'grid',
+    gap: 8,
+};
+
+const listItem: React.CSSProperties = {
+    border: '1px solid #e5e7eb',
+    borderRadius: 8,
+    padding: '12px 16px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 16,
+};
+
+const versionName: React.CSSProperties = {
+    fontWeight: 600,
+    fontSize: 14,
+    color: '#064e3b',
+};
+
+const versionDate: React.CSSProperties = {
+    fontSize: 12,
+    color: '#6b7280',
+    marginTop: 2,
+};
+
+const actionRow: React.CSSProperties = {
+    display: 'flex',
+    gap: 8,
+    flexShrink: 0,
+};
+
+const restoreBtn: React.CSSProperties = {
+    padding: '6px 12px',
+    borderRadius: 6,
+    border: '1px solid #10b981',
+    backgroundColor: '#10b981',
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 500,
+};
+
+const deleteBtn: React.CSSProperties = {
+    padding: '6px 12px',
+    borderRadius: 6,
+    border: '1px solid #ef4444',
+    backgroundColor: '#fff',
+    color: '#ef4444',
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 500,
+};

--- a/src/app/components/MilestoneModal.tsx
+++ b/src/app/components/MilestoneModal.tsx
@@ -29,6 +29,8 @@ export function MilestoneModal({
 }: MilestoneModalProps) {
     // User-entered name for the milestone (optional)
     const [milestoneName, setMilestoneName] = useState('');
+    // ID of the milestone pending delete confirmation; null when no confirm dialog is shown
+    const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
     if (!isOpen) return null;
 
@@ -37,9 +39,20 @@ export function MilestoneModal({
         setMilestoneName('');
     };
 
-    const handleDelete = (event: React.MouseEvent<HTMLButtonElement>, id: string) => {
+    const handleDeleteClick = (event: React.MouseEvent<HTMLButtonElement>, id: string) => {
         event.stopPropagation();
-        onDelete(id);
+        setPendingDeleteId(id);
+    };
+
+    const confirmDelete = () => {
+        if (pendingDeleteId) {
+            onDelete(pendingDeleteId);
+            setPendingDeleteId(null);
+        }
+    };
+
+    const cancelDelete = () => {
+        setPendingDeleteId(null);
     };
 
     return (
@@ -104,7 +117,7 @@ export function MilestoneModal({
                                                 Restore
                                             </button>
                                             <button
-                                                onClick={(e) => handleDelete(e, version.id)}
+                                                onClick={(e) => handleDeleteClick(e, version.id)}
                                                 style={deleteBtn}
                                             >
                                                 Delete
@@ -116,6 +129,19 @@ export function MilestoneModal({
                         </ul>
                     )}
                 </div>
+
+                {/* Delete confirmation dialog */}
+                {pendingDeleteId && (
+                    <div style={confirmOverlay}>
+                        <div style={confirmBox}>
+                            <p style={confirmText}>Are you sure you want to delete this milestone?</p>
+                            <div style={confirmActions}>
+                                <button onClick={cancelDelete} style={confirmCancelBtn}>Cancel</button>
+                                <button onClick={confirmDelete} style={confirmDeleteBtn}>Delete</button>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );
@@ -134,6 +160,7 @@ const overlay: React.CSSProperties = {
 };
 
 const modal: React.CSSProperties = {
+    position: 'relative',
     backgroundColor: '#fff',
     borderRadius: 12,
     padding: 24,
@@ -283,4 +310,59 @@ const deleteBtn: React.CSSProperties = {
     cursor: 'pointer',
     fontSize: 13,
     fontWeight: 500,
+};
+
+/* Delete confirmation dialog styles */
+const confirmOverlay: React.CSSProperties = {
+    position: 'absolute',
+    top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    borderRadius: 12,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 10,
+};
+
+const confirmBox: React.CSSProperties = {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 20,
+    width: 320,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.2)',
+    textAlign: 'center',
+};
+
+const confirmText: React.CSSProperties = {
+    margin: '0 0 16px',
+    fontSize: 14,
+    color: '#064e3b',
+    fontWeight: 500,
+};
+
+const confirmActions: React.CSSProperties = {
+    display: 'flex',
+    gap: 10,
+    justifyContent: 'center',
+};
+
+const confirmCancelBtn: React.CSSProperties = {
+    padding: '8px 20px',
+    background: '#fff',
+    color: '#065f46',
+    border: '1px solid #F0D9A6',
+    borderRadius: 8,
+    cursor: 'pointer',
+    fontSize: 14,
+};
+
+const confirmDeleteBtn: React.CSSProperties = {
+    padding: '8px 20px',
+    background: '#ef4444',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 8,
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 600,
 };

--- a/src/app/hooks/graphVersions.ts
+++ b/src/app/hooks/graphVersions.ts
@@ -57,7 +57,7 @@ export function createVersionActions({
     const openVersionManager = () => setIsVersionModalOpen(true);
     const closeVersionManager = () => setIsVersionModalOpen(false);
 
-    const saveCurrentVersion = () => {
+    const saveCurrentVersion = (customName?: string) => {
         const data = getData();
         if (!data) {
             return;
@@ -65,9 +65,10 @@ export function createVersionActions({
 
         const timestamp = new Date();
         const existing = getVersions();
+        const autoName = createVersionName(timestamp, existing);
         const version: GraphModelVersion = {
             id: createId(),
-            name: createVersionName(timestamp, existing),
+            name: customName?.trim() || autoName,
             savedAt: timestamp.toISOString(),
             data: cloneData(data),
         };

--- a/src/app/hooks/useGraphEditor.ts
+++ b/src/app/hooks/useGraphEditor.ts
@@ -280,11 +280,11 @@ export function useGraphEditor(options: UseGraphEditorOptions = {}): UseGraphEdi
         },
         closeNodeModal: nodeHandlers.closeNodeModal,
         closeTransitionModal,
-        saveCurrentVersion: () => {
+        saveCurrentVersion: (customName?: string) => {
             if (blockIfReadOnly()) {
                 return;
             }
-            versionActions.saveCurrentVersion();
+            versionActions.saveCurrentVersion(customName);
         },
         openVersionManager: versionActions.openVersionManager,
         closeVersionManager: versionActions.closeVersionManager,

--- a/src/app/hooks/useGraphEditor.types.ts
+++ b/src/app/hooks/useGraphEditor.types.ts
@@ -58,7 +58,7 @@ export interface UseGraphEditorResult {
     openAddNodeModal: () => void;
     closeNodeModal: () => void;
     closeTransitionModal: () => void;
-    saveCurrentVersion: () => void;
+    saveCurrentVersion: (customName?: string) => void;
     openVersionManager: () => void;
     closeVersionManager: () => void;
     restoreVersion: (id: string) => void;


### PR DESCRIPTION
Summary
Milestone (#44): Consolidates the "Save Version" and "Versions" toolbar buttons into a single "Milestone" button. Opens a unified modal with a name input to save the current state, and a scrollable history list with Restore/Delete per entry. Delete requires confirmation.
Comment panel (#45): Adds a "Comment" button to the toolbar (right of Help) that toggles a right-side panel. Users can write comments referencing nodes and edges using @[name] syntax. All comments are persisted in localStorage per model. Delete requires confirmation.