### PR TITLE
Add comment bubble on nodes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   ReactFlow,
   ReactFlowProvider,
 } from '@xyflow/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 
 import '@xyflow/react/dist/style.css';
@@ -76,6 +76,7 @@ function GraphEditor() {
   const [isModelListOpen, setIsModelListOpen] = useState(false);
   const [tipsOpen, setTipsOpen] = useState(true);
   const [commentsOpen, setCommentsOpen] = useState(false);
+  const [commentsVersion, setCommentsVersion] = useState(0);
 
   const [auth, setAuth] = useState<{ token: string; user: AuthUser } | null>(() => {
     const token = authStorage.getToken();
@@ -264,6 +265,55 @@ function GraphEditor() {
   });
 
   const modelName = bmrgData?.stm_name?.trim() || null;
+
+  useEffect(() => {
+    if (!modelName) return;
+
+    const timer = window.setInterval(() => {
+      setCommentsVersion((prev) => prev + 1);
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [modelName]);
+
+  const commentCountMap = useMemo(() => {
+    if (!modelName) return {} as Record<string, number>;
+
+    try {
+      const raw = localStorage.getItem(`stmCreator.comments.${modelName}`);
+      const comments = raw ? JSON.parse(raw) : [];
+      const counts: Record<string, number> = {};
+
+      nodesWithCallbacks.forEach((node) => {
+        const label = ((node.data as any)?.label || '').trim();
+        if (!label) return;
+
+        const mentionToken = `@[${label}]`;
+
+        const count = comments.filter((comment: any) =>
+          typeof comment?.text === 'string' && comment.text.includes(mentionToken)
+        ).length;
+
+        counts[node.id] = count;
+      });
+
+      return counts;
+    } catch {
+      return {} as Record<string, number>;
+    }
+  }, [modelName, nodesWithCallbacks, commentsVersion]);
+
+  const nodesForRender = nodesWithCallbacks.map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      commentCount: commentCountMap[node.id] ?? 0,
+      onCommentBubbleClick: () => {
+        setCommentsOpen(true);
+        setTipsOpen(false);
+      },
+    },
+  }));
 
   const handleNodePatch = (field: string, value: unknown) => {
     const nodeId = initialNodeValues?.id;
@@ -708,7 +758,7 @@ function GraphEditor() {
           onMouseLeave={handleCanvasMouseLeave}
         >
           <ReactFlow
-            nodes={nodesWithCallbacks}
+            nodes={nodesForRender}
             edges={edges}
             nodeTypes={nodeTypes}
             edgeTypes={customEdgeTypes}
@@ -780,10 +830,10 @@ function GraphEditor() {
             {commentsOpen ? (
               <CommentPanel
                 onClose={() => setCommentsOpen(false)}
-                nodes={nodesWithCallbacks.map(n => ({ id: n.id, label: (n.data as any).label || n.id }))}
+                nodes={nodesForRender.map(n => ({ id: n.id, label: (n.data as any).label || n.id }))}
                 edges={edges.map(e => {
-                  const srcNode = nodesWithCallbacks.find(n => n.id === e.source);
-                  const tgtNode = nodesWithCallbacks.find(n => n.id === e.target);
+                  const srcNode = nodesForRender.find(n => n.id === e.source);
+                  const tgtNode = nodesForRender.find(n => n.id === e.target);
                   return {
                     id: e.id,
                     sourceLabel: (srcNode?.data as any)?.label || e.source,

--- a/src/nodes/customNode.css
+++ b/src/nodes/customNode.css
@@ -231,3 +231,30 @@
 .node-container:hover .handle {
   opacity: 1;
 }
+
+.node-comment-bubble {
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  min-width: 30px;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid #bfdbfe;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  z-index: 6;
+}
+
+.node-comment-bubble:hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+}

--- a/src/nodes/customNode.tsx
+++ b/src/nodes/customNode.tsx
@@ -67,6 +67,10 @@ export function CustomNode({ data, id }: CustomNodeProps) {
             data.onNodeClick(id);
         }
     };
+    const handleCommentBubbleClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        data.onCommentBubbleClick?.(id);
+    };
 
     const stateNumber = data.attributes?.stateNumber || '';
     const vastClass = data.attributes?.vastClass || '';
@@ -121,6 +125,16 @@ export function CustomNode({ data, id }: CustomNodeProps) {
                         <div className={`state-number-badge class-color-${classNum}-bg`}>
                             {stateNumber}
                         </div>
+                    )}
+                    {(data.commentCount ?? 0) > 0 && (
+                        <button
+                            type="button"
+                            className="node-comment-bubble"
+                            onClick={handleCommentBubbleClick}
+                            title={`${data.commentCount} comment${data.commentCount === 1 ? '' : 's'}`}
+                        >
+                            💬 {data.commentCount}
+                        </button>
                     )}
 
                     <div className="node-header">

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -14,6 +14,8 @@ export type CustomNodeData = {
     isLockedByMe?: boolean;
     lockOwner?: string | null;
     lockColor?: string | null;
+    commentCount?: number;
+    onCommentBubbleClick?: (id: string) => void;
 };
 
 export type PositionLoggerNode = Node<CustomNodeData, 'position-logger'>;


### PR DESCRIPTION
Summary:
- add comment bubble on nodes
- show comment count based on node mentions in comments
- keep existing comment storage unchanged

Testing:
- created a node and mentioned it in comments
- verified bubble count appears and increases correctly
- verified multiple comments update the count