### PR TITLE
feat: Canvas UX improvements — node density, right-click menu, legend & edge colours

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -241,6 +241,23 @@
   margin-bottom: 10px;
 }
 
+/* When the sidebar-label is interactive (legend collapse toggle), strip
+   default button chrome but keep the same typographic styling. */
+button.sidebar-label.legend-toggle {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+button.sidebar-label.legend-toggle:hover {
+  color: var(--text-muted);
+}
+
 .sidebar-divider {
   height: 1px;
   background: var(--border);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import { ErrorState } from './app/components/ErrorState';
 import { LoadingState } from './app/components/LoadingState';
 import { TipsPanel } from './app/components/TipsPanel';
 import { CommentPanel } from './app/components/CommentPanel';
+import {
+    CanvasContextMenu,
+    type CanvasContextMenuState,
+} from './app/components/CanvasContextMenu';
 import { MilestoneModal } from './app/components/MilestoneModal';
 import { ModelListModal } from './app/components/ModelListModal';
 import { HelpModal } from './app/components/HelpModal';
@@ -239,6 +243,8 @@ function GraphEditor() {
     handleSaveModel,
     handleDeleteState,
     handleDeleteModel,
+    openEditNode,
+    openEditTransition,
     handleReLayout,
     applyLayout,
     toggleEdgeCreationMode,
@@ -265,6 +271,86 @@ function GraphEditor() {
   });
 
   const modelName = bmrgData?.stm_name?.trim() || null;
+
+  // Right-click context menu state for canvas (state nodes & transition edges).
+  const [contextMenu, setContextMenu] =
+    useState<(CanvasContextMenuState & {
+      // Cached identifiers for the action handlers below — keeps the menu
+      // closure simple and avoids re-resolving on click.
+      readonly nodeId?: string;
+      readonly graphStateId?: number;
+      readonly transitionId?: number;
+    }) | null>(null);
+
+  const handleNodeContextMenu = (
+    event: React.MouseEvent,
+    node: { id: string },
+  ) => {
+    if (!baseCanEdit) return;
+    event.preventDefault();
+    const graphStateId = parseStateId(node.id);
+    if (graphStateId === null) return;
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      target: 'state',
+      nodeId: node.id,
+      graphStateId,
+    });
+  };
+
+  const handleEdgeContextMenu = (
+    event: React.MouseEvent,
+    edge: { id: string },
+  ) => {
+    if (!baseCanEdit) return;
+    event.preventDefault();
+    const match = /^transition-(\d+)$/.exec(edge.id);
+    if (!match) return;
+    const transitionId = parseInt(match[1], 10);
+    if (Number.isNaN(transitionId)) return;
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      target: 'transition',
+      transitionId,
+    });
+  };
+
+  const closeContextMenu = () => setContextMenu(null);
+
+  const handleContextMenuEdit = () => {
+    if (!contextMenu) return;
+    if (contextMenu.target === 'state' && contextMenu.nodeId) {
+      openEditNode(contextMenu.nodeId);
+    } else if (
+      contextMenu.target === 'transition' &&
+      typeof contextMenu.transitionId === 'number'
+    ) {
+      openEditTransition(contextMenu.transitionId);
+    }
+  };
+
+  const handleContextMenuDelete = () => {
+    if (!contextMenu) return;
+    if (
+      contextMenu.target === 'state' &&
+      typeof contextMenu.graphStateId === 'number'
+    ) {
+      handleDeleteState(contextMenu.graphStateId);
+    } else if (
+      contextMenu.target === 'transition' &&
+      typeof contextMenu.transitionId === 'number' &&
+      bmrgData
+    ) {
+      const transition = bmrgData.transitions.find(
+        (t) => t.transition_id === contextMenu.transitionId,
+      );
+      if (transition) {
+        handleDeleteTransition(transition);
+      }
+    }
+  };
 
   useEffect(() => {
     if (!modelName) return;
@@ -778,6 +864,14 @@ function GraphEditor() {
             onConnect={onConnect}
             onEdgeClick={onEdgeClick}
             onEdgeDoubleClick={onEdgeDoubleClick}
+            onNodeContextMenu={handleNodeContextMenu}
+            onEdgeContextMenu={handleEdgeContextMenu}
+            onPaneContextMenu={(event) => {
+              // Right-clicking empty canvas dismisses the menu but otherwise
+              // keeps the browser's default suppressed for a consistent feel.
+              event.preventDefault();
+              closeContextMenu();
+            }}
             onNodeDragStart={handleNodeDragStart}
             onNodeDrag={handleNodeDrag}
             onNodeDragStop={handleNodeDragStop}
@@ -909,6 +1003,13 @@ function GraphEditor() {
 
       <HelpModal isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
       <ModelListModal isOpen={isModelListOpen} onClose={() => setIsModelListOpen(false)} />
+
+      <CanvasContextMenu
+        menu={contextMenu}
+        onClose={closeContextMenu}
+        onEdit={handleContextMenuEdit}
+        onDelete={handleContextMenuDelete}
+      />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -821,7 +821,7 @@ function GraphEditor() {
       <div className="workspace">
         <div className="sidebar">
           <div className="sidebar-section">
-            <div className="sidebar-label">Classes</div>
+            <div className="sidebar-label">Condition classes</div>
             {legendItems.map((item) => (
               <div className="legend-item" key={item.cls}>
                 <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,25 @@ function GraphEditor() {
   const [isModelListOpen, setIsModelListOpen] = useState(false);
   const [tipsOpen, setTipsOpen] = useState(true);
   const [commentsOpen, setCommentsOpen] = useState(false);
+  // Sidebar legend collapse/expand state. Persisted in localStorage so the
+  // user's choice sticks across sessions; defaults to expanded.
+  const [legendCollapsed, setLegendCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('stmCreator.legendCollapsed') === '1';
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        'stmCreator.legendCollapsed',
+        legendCollapsed ? '1' : '0',
+      );
+    } catch {
+      // ignore quota / private-mode failures — the toggle still works
+    }
+  }, [legendCollapsed]);
   const [commentsVersion, setCommentsVersion] = useState(0);
 
   const [auth, setAuth] = useState<{ token: string; user: AuthUser } | null>(() => {
@@ -671,13 +690,16 @@ function GraphEditor() {
     }
   }
 
+  // Swatch colours mirror the rendered node colours from customNode.css
+  // (.class-color-1 .. .class-color-6). Keep these in sync if those change
+  // — the legend is meant to be a faithful preview of the canvas.
   const legendItems = [
-    { cls: 'Class I', label: 'Reference', bg: '#dcfce7', border: '#86efac' },
-    { cls: 'Class II', label: 'Class II', bg: '#ecfccb', border: '#bef264' },
-    { cls: 'Class III', label: 'Class III', bg: '#fef9c3', border: '#fde047' },
-    { cls: 'Class IV', label: 'Class IV', bg: '#fef3c7', border: '#fcd34d' },
-    { cls: 'Class V', label: 'Class V', bg: '#ffedd5', border: '#fdba74' },
-    { cls: 'Class VI', label: 'Class VI', bg: '#fee2e2', border: '#fca5a5' },
+    { cls: 'Class I', label: 'Reference', bg: '#f0fdf4', border: '#bbf7d0' },
+    { cls: 'Class II', label: 'Class II', bg: '#f7fee7', border: '#d9f99d' },
+    { cls: 'Class III', label: 'Class III', bg: '#fefce8', border: '#fef08a' },
+    { cls: 'Class IV', label: 'Class IV', bg: '#fffbeb', border: '#fde68a' },
+    { cls: 'Class V', label: 'Class V', bg: '#fff7ed', border: '#fed7aa' },
+    { cls: 'Class VI', label: 'Class VI', bg: '#fef2f2', border: '#fecaca' },
   ];
 
   const handleCanvasMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -821,17 +843,42 @@ function GraphEditor() {
       <div className="workspace">
         <div className="sidebar">
           <div className="sidebar-section">
-            <div className="sidebar-label">Condition classes</div>
-            {legendItems.map((item) => (
-              <div className="legend-item" key={item.cls}>
-                <div
-                  className="legend-swatch"
-                  style={{ background: item.bg, border: `1px solid ${item.border}` }}
-                />
-                <span className="legend-text">{item.label}</span>
-                <span className="legend-count">{classCountMap[item.cls] || 0}</span>
+            <button
+              type="button"
+              className="sidebar-label legend-toggle"
+              onClick={() => setLegendCollapsed((v) => !v)}
+              aria-expanded={!legendCollapsed}
+              aria-controls="legend-list"
+              title={legendCollapsed ? 'Expand legend' : 'Collapse legend'}
+            >
+              <span
+                className="legend-toggle-arrow"
+                aria-hidden="true"
+                style={{
+                  display: 'inline-block',
+                  marginRight: 6,
+                  transform: legendCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+                  transition: 'transform .15s ease',
+                }}
+              >
+                ▾
+              </span>
+              Condition classes
+            </button>
+            {!legendCollapsed && (
+              <div id="legend-list">
+                {legendItems.map((item) => (
+                  <div className="legend-item" key={item.cls}>
+                    <div
+                      className="legend-swatch"
+                      style={{ background: item.bg, border: `1px solid ${item.border}` }}
+                    />
+                    <span className="legend-text">{item.label}</span>
+                    <span className="legend-count">{classCountMap[item.cls] || 0}</span>
+                  </div>
+                ))}
               </div>
-            ))}
+            )}
           </div>
 
           <div className="sidebar-divider" />

--- a/src/app/components/CanvasContextMenu.tsx
+++ b/src/app/components/CanvasContextMenu.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+
+export type CanvasContextTarget = 'state' | 'transition';
+
+export interface CanvasContextMenuState {
+    readonly x: number;
+    readonly y: number;
+    readonly target: CanvasContextTarget;
+}
+
+interface Props {
+    readonly menu: CanvasContextMenuState | null;
+    readonly onClose: () => void;
+    readonly onEdit: () => void;
+    readonly onDelete: () => void;
+}
+
+// Floating right-click context menu shown on top of the canvas.
+// Renders with two actions ("Edit" / "Delete") for either a state node or a
+// transition edge. Dismisses on click-away or Escape.
+export function CanvasContextMenu({ menu, onClose, onEdit, onDelete }: Props) {
+    useEffect(() => {
+        if (!menu) {
+            return;
+        }
+        const handleMouseDown = () => onClose();
+        const handleKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        // Use a microtask delay so the same click that opened the menu
+        // doesn't immediately close it.
+        const timer = window.setTimeout(() => {
+            window.addEventListener('mousedown', handleMouseDown);
+        }, 0);
+        window.addEventListener('keydown', handleKey);
+        return () => {
+            window.clearTimeout(timer);
+            window.removeEventListener('mousedown', handleMouseDown);
+            window.removeEventListener('keydown', handleKey);
+        };
+    }, [menu, onClose]);
+
+    if (!menu) {
+        return null;
+    }
+
+    const label = menu.target === 'state' ? 'state' : 'transition';
+
+    return (
+        <div
+            role="menu"
+            onMouseDown={(e) => e.stopPropagation()}
+            onContextMenu={(e) => e.preventDefault()}
+            style={{
+                position: 'fixed',
+                top: menu.y,
+                left: menu.x,
+                zIndex: 2000,
+                background: 'white',
+                border: '1px solid #e5e7eb',
+                borderRadius: 6,
+                boxShadow: '0 8px 24px rgba(0, 0, 0, 0.12)',
+                padding: 4,
+                minWidth: 160,
+                fontSize: 13,
+            }}
+        >
+            <button
+                type="button"
+                onClick={() => {
+                    onEdit();
+                    onClose();
+                }}
+                style={menuButtonStyle}
+                onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = '#f3f4f6';
+                }}
+                onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+                }}
+            >
+                Edit {label}
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    onDelete();
+                    onClose();
+                }}
+                style={{ ...menuButtonStyle, color: '#b91c1c' }}
+                onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = '#fef2f2';
+                }}
+                onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+                }}
+            >
+                Delete {label}
+            </button>
+        </div>
+    );
+}
+
+const menuButtonStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: '6px 10px',
+    border: 'none',
+    background: 'transparent',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 13,
+    fontFamily: 'inherit',
+};

--- a/src/app/hooks/graphDeletes.ts
+++ b/src/app/hooks/graphDeletes.ts
@@ -30,13 +30,20 @@ export function createDeleteActions({ getData, setData, setNodes, rebuildEdges, 
       removeTransitionLocal(tId as any);
       return;
     }
+    if (!confirm(`Delete transition ${tId}? This cannot be undone.`)) return;
+
+    // Optimistically remove from local state first so the canvas updates
+    // immediately, even when the transition was never saved to the backend
+    // (in which case the API DELETE would 404). The next Save Model will
+    // reconcile any out-of-band differences.
+    removeTransitionLocal(tId);
+
     try {
-      if (!confirm(`Delete transition ${tId}? This cannot be undone.`)) return;
       await apiDeleteTransition(data.stm_name, tId);
-      removeTransitionLocal(tId);
-      alert('Transition deleted');
     } catch (e) {
-      alert((e as Error).message || 'Failed to delete transition');
+      // Don't roll back — the local removal is the user's intent. Surface
+      // non-trivial errors to the console for debugging.
+      console.warn('Backend delete for transition failed (kept local removal):', tId, e);
     }
   };
 
@@ -47,25 +54,28 @@ export function createDeleteActions({ getData, setData, setNodes, rebuildEdges, 
     const st = data.states.find(s => (s.state_id ?? s.frontend_state_id) === graphStateId);
     if (!st) return;
     const dbId = st.state_id;
-    try {
-      if (!confirm(`Delete state "${st.state_name}" and its related transitions?`)) return;
-      if (typeof dbId === 'number') {
+    if (!confirm(`Delete state "${st.state_name}" and its related transitions?`)) return;
+
+    // Optimistically remove locally first (state + connected transitions +
+    // recompute nodes/edges). The next Save Model will reconcile any
+    // out-of-band differences if the backend call fails.
+    setData(prev => {
+      if (!prev) return prev;
+      const remainingStates = prev.states.filter(s => (s.state_id ?? s.frontend_state_id) !== graphStateId);
+      const remainingTransitions = prev.transitions.filter(t => t.start_state_id !== graphStateId && t.end_state_id !== graphStateId);
+      const next: BMRGData = { ...prev, states: remainingStates, transitions: remainingTransitions };
+      const nodes = statesToNodes(next.states, handleNodeLabelChange, handleNodeClick, next.transitions);
+      setNodes(nodes);
+      rebuildEdges({ transitions: remainingTransitions, dataOverride: next });
+      return next;
+    });
+
+    if (typeof dbId === 'number') {
+      try {
         await apiDeleteState(data.stm_name, dbId);
+      } catch (e) {
+        console.warn('Backend delete for state failed (kept local removal):', dbId, e);
       }
-      // local removal of state and any transitions using it
-      setData(prev => {
-        if (!prev) return prev;
-        const remainingStates = prev.states.filter(s => (s.state_id ?? s.frontend_state_id) !== graphStateId);
-        const remainingTransitions = prev.transitions.filter(t => t.start_state_id !== graphStateId && t.end_state_id !== graphStateId);
-        const next: BMRGData = { ...prev, states: remainingStates, transitions: remainingTransitions };
-        const nodes = statesToNodes(next.states, handleNodeLabelChange, handleNodeClick, next.transitions);
-        setNodes(nodes);
-        rebuildEdges({ transitions: remainingTransitions, dataOverride: next });
-        return next;
-      });
-      alert('State deleted');
-    } catch (e) {
-      alert((e as Error).message || 'Failed to delete state');
     }
   };
 

--- a/src/app/hooks/graphMutations.ts
+++ b/src/app/hooks/graphMutations.ts
@@ -178,6 +178,7 @@ export function createCustomNode(
             condition: attributes.condition,
             imageUrl: attributes.imageUrl,
             note: attributes.note,
+            template: attributes.template,
         },
     };
 

--- a/src/app/hooks/graphMutations.ts
+++ b/src/app/hooks/graphMutations.ts
@@ -164,6 +164,7 @@ export function applyNodePatch(nodes: AppNode[], nodeId: string, field: string, 
 
 export function createCustomNode(
     attributes: NodeAttributes,
+    stateId: number,
     onLabelChange: (id: string, label: string) => void,
     onNodeClick: (id: string) => void,
 ): AppNode {
@@ -183,7 +184,11 @@ export function createCustomNode(
     };
 
     return {
-        id: `node-${Date.now()}`,
+        // Use the BMRG frontend_state_id as the React Flow node id so it stays
+        // in sync with transitionsToEdges() and parseStateId() (both expect
+        // the `state-N` prefix). Using a timestamp here would orphan the node
+        // from the BMRG state and silently break edge creation/editing.
+        id: `state-${stateId}`,
         type: 'custom',
         data: nodeData,
         position: {

--- a/src/app/hooks/graphNodes.ts
+++ b/src/app/hooks/graphNodes.ts
@@ -31,6 +31,7 @@ interface Dependencies {
     setIsNodeModalOpen: Dispatch<SetStateAction<boolean>>;
     getIsEditing: () => boolean;
     getCurrentNodeId: () => string | null;
+    getData: () => BMRGData | null;
     setData: Dispatch<SetStateAction<BMRGData | null>>;
     handleNodeLabelChange: (nodeId: string, label: string) => void;
     requestNodeEdit?: (nodeId: string) => Promise<boolean>;
@@ -50,6 +51,7 @@ export function createNodeHandlers({
     setIsNodeModalOpen,
     getIsEditing,
     getCurrentNodeId,
+    getData,
     setData,
     handleNodeLabelChange,
     requestNodeEdit,
@@ -113,16 +115,30 @@ export function createNodeHandlers({
                 return updateBmrgStateName(prev, stateId, attributes);
             });
         } else {
+            // Use the same numeric id for BOTH the React Flow node (`state-N`)
+            // and the BMRG state's frontend_state_id, so parseStateId() can
+            // recover the BMRG state from the React Flow edge endpoints. This
+            // is required for transition creation/editing to work for newly
+            // added nodes.
+            const data = getData();
+            if (!data) {
+                return;
+            }
+            const nextStateId = nextFrontendStateId(data.states);
+
             setNodes((prev) => [
                 ...prev,
-                createCustomNode(attributes, handleNodeLabelChange, handleNodeClick),
+                createCustomNode(
+                    attributes,
+                    nextStateId,
+                    handleNodeLabelChange,
+                    handleNodeClick,
+                ),
             ]);
             setData((prev) => {
                 if (!prev) {
                     return prev;
                 }
-
-                const nextStateId = nextFrontendStateId(prev.states);
                 const newState = buildStateFromAttributes(attributes, nextStateId);
                 return addStateToBmrg(prev, newState);
             });

--- a/src/app/hooks/useGraphEditor.ts
+++ b/src/app/hooks/useGraphEditor.ts
@@ -90,6 +90,7 @@ export function useGraphEditor(options: UseGraphEditorOptions = {}): UseGraphEdi
         setIsNodeModalOpen: state.setIsNodeModalOpen,
         getIsEditing: () => state.isEditing,
         getCurrentNodeId: () => state.currentNodeId,
+        getData: () => state.bmrgData,
         setData: state.setBmrgData,
         handleNodeLabelChange,
         requestNodeEdit: options.requestNodeEdit,

--- a/src/app/hooks/useGraphEditor.ts
+++ b/src/app/hooks/useGraphEditor.ts
@@ -268,6 +268,34 @@ export function useGraphEditor(options: UseGraphEditorOptions = {}): UseGraphEdi
             }
             void deleteActions.handleDeleteModel();
         },
+        // Open the node editor (NodeModal) for an existing node id. Reuses
+        // the same flow as clicking on a node — including the lock-acquire
+        // step. Used by the canvas right-click context menu.
+        openEditNode: (nodeId) => {
+            if (blockIfReadOnly()) {
+                return;
+            }
+            nodeHandlers.handleNodeClick(nodeId);
+        },
+        // Open the transition editor (TransitionModal) for an existing
+        // transition id. Used by the canvas right-click context menu.
+        openEditTransition: (transitionId) => {
+            if (blockIfReadOnly()) {
+                return;
+            }
+            const data = state.bmrgData;
+            if (!data) {
+                return;
+            }
+            const transition = data.transitions.find(
+                (item) => item.transition_id === transitionId,
+            );
+            if (!transition) {
+                return;
+            }
+            state.setCurrentTransition(transition);
+            openTransitionModal();
+        },
         handleReLayout: modelActions.handleReLayout,
         applyLayout: canEdit
             ? layoutActions.applyLayout

--- a/src/app/hooks/useGraphEditor.types.ts
+++ b/src/app/hooks/useGraphEditor.types.ts
@@ -50,6 +50,8 @@ export interface UseGraphEditorResult {
     handleSaveModel: () => Promise<SaveModelResponse>;
     handleDeleteState: (graphStateId: number) => void;
     handleDeleteModel: () => void;
+    openEditNode: (nodeId: string) => void;
+    openEditTransition: (transitionId: number) => void;
     handleReLayout: () => void;
     applyLayout?: (strategy: LayoutStrategy) => Promise<void> | void;
     toggleEdgeCreationMode: () => void;

--- a/src/edges/customEdge.tsx
+++ b/src/edges/customEdge.tsx
@@ -138,10 +138,19 @@ export default function CustomEdge({
 
     // Get transition delta value for styling
     const transitionDelta = (data?.transitionDelta as number) ?? 0;
-    const isNegativeDelta = (transitionDelta as number) < 0;
+    const isNegativeDelta = transitionDelta < 0;
+    const isZeroDelta = transitionDelta === 0;
 
-    // Determine edge color based on transition delta
-    const edgeColor = isNegativeDelta ? '#ff5555' : '#55aa55';
+    // Determine edge color based on transition delta:
+    //   positive → green, negative → red, zero → gray
+    let edgeColor: string;
+    if (isZeroDelta) {
+        edgeColor = '#9ca3af';
+    } else if (isNegativeDelta) {
+        edgeColor = '#ff5555';
+    } else {
+        edgeColor = '#55aa55';
+    }
     const edgeWidth = Math.max(1, Math.abs(transitionDelta) * 5 + 1);
 
     // Adjust label positioning for better visibility

--- a/src/nodes/customNode.css
+++ b/src/nodes/customNode.css
@@ -1,7 +1,7 @@
 /* ─── NODE CONTAINER ─── */
 .node-container {
-  width: 192px;
-  min-height: 80px;
+  width: 168px;
+  min-height: 76px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--node-r);
@@ -38,7 +38,7 @@
   position: absolute;
   top: -14px;
   left: 10px;
-  max-width: 170px;
+  max-width: 148px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -97,9 +97,9 @@
 }
 
 .state-name {
-  font-size: 11.5px;
+  font-size: 10.5px;
   font-weight: 500;
-  line-height: 1.4;
+  line-height: 1.35;
   color: var(--text);
   text-align: left;
   word-wrap: break-word;
@@ -134,7 +134,7 @@
   width: 90%;
   border: none;
   outline: none;
-  font-size: 11.5px;
+  font-size: 10.5px;
   font-family: inherit;
   padding: 5px;
   background: var(--surface2);

--- a/src/nodes/nodeModal.tsx
+++ b/src/nodes/nodeModal.tsx
@@ -1,4 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+    BIOMES,
+    BIOME_ORDER,
+    TEMPLATES_BY_ID,
+    listPrimaryGroupOptions,
+    listTemplatesForGroup,
+    makeTemplateRef,
+    primaryGroupKeyOf,
+    type BiomeType,
+    type TemplateRef,
+} from './templates';
 
 export interface NodeAttributes {
     stateName: string;
@@ -8,6 +19,7 @@ export interface NodeAttributes {
 	imageUrl?: string;
     note?: string;
     id?: string; // Optional for editing existing nodes
+    template?: TemplateRef; // Optional template selection from biome taxonomy
 }
 
 interface NodeModalProps {
@@ -44,6 +56,12 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
     const [lowerBound, setLowerBound] = useState<string>('');
     const [upperBound, setUpperBound] = useState<string>('');
 
+    // Three-level template selection (all optional).
+    // Level 1: biome; Level 2: primary-group key; Level 3: concrete template id.
+    const [biome, setBiome] = useState<BiomeType | ''>('');
+    const [primaryGroupKey, setPrimaryGroupKey] = useState<string>('');
+    const [templateId, setTemplateId] = useState<string>('');
+
     // Update form when initialValues changes (when editing an existing node)
 	useEffect(() => {
         if (initialValues) {
@@ -60,6 +78,19 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
                 setLowerBound('');
                 setUpperBound('');
             }
+
+            // Rehydrate template dropdowns from the stored ref, if any.
+            const storedRef = initialValues.template;
+            const storedTemplate = storedRef ? TEMPLATES_BY_ID[storedRef.id] : undefined;
+            if (storedTemplate) {
+                setBiome(storedTemplate.biome);
+                setPrimaryGroupKey(primaryGroupKeyOf(storedTemplate));
+                setTemplateId(storedTemplate.id);
+            } else {
+                setBiome('');
+                setPrimaryGroupKey('');
+                setTemplateId('');
+            }
 		} else {
             // Reset form when opening for a new node
             setAttributes({
@@ -72,8 +103,72 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
             });
             setLowerBound('');
             setUpperBound('');
+            setBiome('');
+            setPrimaryGroupKey('');
+            setTemplateId('');
         }
     }, [initialValues, isOpen]);
+
+    // Options for the 2nd and 3rd dropdowns depend on the selections above.
+    const primaryGroupOptions = useMemo(
+        () => (biome ? listPrimaryGroupOptions(biome) : []),
+        [biome],
+    );
+    const templateOptions = useMemo(
+        () => (biome && primaryGroupKey ? listTemplatesForGroup(biome, primaryGroupKey) : []),
+        [biome, primaryGroupKey],
+    );
+
+    const handleBiomeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value as BiomeType | '';
+        setBiome(value);
+        setPrimaryGroupKey('');
+        setTemplateId('');
+        setAttributes((prev) => ({ ...prev, template: undefined }));
+        if (isEditing) {
+            onPatch?.('template', undefined);
+        }
+    };
+
+    const handlePrimaryGroupChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        setPrimaryGroupKey(e.target.value);
+        setTemplateId('');
+        setAttributes((prev) => ({ ...prev, template: undefined }));
+        if (isEditing) {
+            onPatch?.('template', undefined);
+        }
+    };
+
+    const handleTemplateChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const id = e.target.value;
+        setTemplateId(id);
+        const t = TEMPLATES_BY_ID[id];
+        if (!t) {
+            setAttributes((prev) => ({ ...prev, template: undefined }));
+            if (isEditing) {
+                onPatch?.('template', undefined);
+            }
+            return;
+        }
+        const ref = makeTemplateRef(t);
+        setAttributes((prev) => {
+            // Pre-fill stateName only if the user has not typed anything yet,
+            // so we don't silently overwrite a value they entered earlier.
+            const shouldPrefillName = !prev.stateName || prev.stateName.trim() === '';
+            const next: NodeAttributes = {
+                ...prev,
+                template: ref,
+                stateName: shouldPrefillName ? t.label : prev.stateName,
+            };
+            if (isEditing && shouldPrefillName) {
+                onPatch?.('stateName', next.stateName);
+            }
+            return next;
+        });
+        if (isEditing) {
+            onPatch?.('template', ref);
+        }
+    };
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
@@ -136,6 +231,111 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
                 <h2 style={{ marginTop: 0 }}>{isEditing ? 'Edit Node' : 'Add New Node'}</h2>
 
                 <form onSubmit={handleSubmit}>
+                    <div
+                        style={{
+                            marginBottom: '15px',
+                            padding: '10px',
+                            borderRadius: '6px',
+                            border: '1px solid #e5e7eb',
+                            backgroundColor: '#f9fafb',
+                        }}
+                    >
+                        <div style={{ fontWeight: 600, marginBottom: '8px' }}>
+                            Template <span style={{ color: '#6b7280', fontWeight: 400 }}>(optional)</span>
+                        </div>
+
+                        <label style={{ display: 'block', marginBottom: '8px' }}>
+                            <span style={{ display: 'block', marginBottom: '4px', fontSize: '13px' }}>
+                                Biome
+                            </span>
+                            <select
+                                value={biome}
+                                onChange={handleBiomeChange}
+                                style={{
+                                    width: '100%',
+                                    padding: '8px',
+                                    borderRadius: '4px',
+                                    border: '1px solid #ccc',
+                                    backgroundColor: 'white',
+                                }}
+                            >
+                                <option value="">Select a biome</option>
+                                {BIOME_ORDER.map((b) => (
+                                    <option key={b} value={b}>
+                                        {BIOMES[b].label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label style={{ display: 'block', marginBottom: '8px' }}>
+                            <span style={{ display: 'block', marginBottom: '4px', fontSize: '13px' }}>
+                                Primary Layer
+                            </span>
+                            <select
+                                value={primaryGroupKey}
+                                onChange={handlePrimaryGroupChange}
+                                disabled={!biome}
+                                style={{
+                                    width: '100%',
+                                    padding: '8px',
+                                    borderRadius: '4px',
+                                    border: '1px solid #ccc',
+                                    backgroundColor: biome ? 'white' : '#f3f4f6',
+                                }}
+                            >
+                                <option value="">
+                                    {biome ? 'Select a primary layer' : 'Select a biome first'}
+                                </option>
+                                {primaryGroupOptions.map((opt) => (
+                                    <option key={opt.key} value={opt.key}>
+                                        {opt.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label style={{ display: 'block' }}>
+                            <span style={{ display: 'block', marginBottom: '4px', fontSize: '13px' }}>
+                                Template
+                            </span>
+                            <select
+                                value={templateId}
+                                onChange={handleTemplateChange}
+                                disabled={!primaryGroupKey}
+                                style={{
+                                    width: '100%',
+                                    padding: '8px',
+                                    borderRadius: '4px',
+                                    border: '1px solid #ccc',
+                                    backgroundColor: primaryGroupKey ? 'white' : '#f3f4f6',
+                                }}
+                            >
+                                <option value="">
+                                    {primaryGroupKey ? 'Select a template' : 'Select a primary layer first'}
+                                </option>
+                                {templateOptions.map((t) => (
+                                    <option key={t.id} value={t.id}>
+                                        {t.shortLabel}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        {attributes.template && (
+                            <div
+                                style={{
+                                    marginTop: '8px',
+                                    fontSize: '12px',
+                                    color: '#374151',
+                                    fontStyle: 'italic',
+                                }}
+                            >
+                                Selected: {attributes.template.label}
+                            </div>
+                        )}
+                    </div>
+
                     <div style={{ marginBottom: '15px' }}>
                         <label style={{ display: 'block', marginBottom: '5px' }}>
                             State Name:

--- a/src/nodes/nodeModal.tsx
+++ b/src/nodes/nodeModal.tsx
@@ -32,8 +32,10 @@ interface NodeModalProps {
     readonly isEditing: boolean;
 }
 
-// VAST classes from the JSON data
-const VAST_CLASSES = [
+// Condition classes from the JSON data.
+// (Backing data field is still vastClass to avoid a schema migration —
+// see issue #56 for the full rename plan.)
+const CONDITION_CLASSES = [
     "Class I",
     "Class II",
     "Class III",
@@ -375,7 +377,7 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
 
                     <div style={{ marginBottom: '15px' }}>
                         <label style={{ display: 'block', marginBottom: '5px' }}>
-                            VAST Class:
+                            Condition class:
                             <select
                                 name="vastClass"
                                 value={attributes.vastClass}
@@ -388,9 +390,9 @@ export function NodeModal({ isOpen, onClose, onSave, onPatch, onDelete, initialV
                                 }}
                             >
                                 <option value="">Select a class</option>
-                                {VAST_CLASSES.map(vastClass => (
-                                    <option key={vastClass} value={vastClass}>
-                                        {vastClass}
+                                {CONDITION_CLASSES.map(conditionClass => (
+                                    <option key={conditionClass} value={conditionClass}>
+                                        {conditionClass}
                                     </option>
                                 ))}
                             </select>

--- a/src/nodes/templates.ts
+++ b/src/nodes/templates.ts
@@ -1,0 +1,304 @@
+// Template data model for node creation.
+// Based on Supporting Information S4 — primary templates for forests/woodlands,
+// shrublands and grasslands (Jan 2026 working draft).
+
+export type BiomeType = 'woodlands' | 'shrublands' | 'grasslands';
+
+// Four standard layer conditions used by the 4x4 matrix.
+export type LayerCondition =
+    | 'close-to-reference'
+    | 'modified'
+    | 'highly-modified'
+    | 'collapsed-transformer';
+
+// Second-level dropdown "group". The layer group uses a LayerCondition for the
+// primary layer of the biome; the two special groups cover cultivated-woody
+// systems and intensive land uses.
+export type PrimaryGroupKind = 'layer' | 'cultivated-woody' | 'intensive';
+
+export interface BiomeConfig {
+    readonly id: BiomeType;
+    readonly label: string;
+    readonly primaryLayerName: string;   // e.g. "tree layer"
+    readonly secondaryLayerName: string; // e.g. "shrub/ground layers"
+    // Whether the "highly modified" condition is labelled "/absent" in this
+    // biome. Woodlands and shrublands use "Highly modified/absent" in the
+    // individual template labels; grasslands use just "Highly modified".
+    readonly highlyModifiedIncludesAbsent: boolean;
+}
+
+export const BIOMES: Record<BiomeType, BiomeConfig> = {
+    woodlands: {
+        id: 'woodlands',
+        label: 'Woodlands',
+        primaryLayerName: 'tree layer',
+        secondaryLayerName: 'shrub/ground layers',
+        highlyModifiedIncludesAbsent: true,
+    },
+    shrublands: {
+        id: 'shrublands',
+        label: 'Shrublands',
+        primaryLayerName: 'shrub layer',
+        secondaryLayerName: 'tree/ground layers',
+        highlyModifiedIncludesAbsent: true,
+    },
+    grasslands: {
+        id: 'grasslands',
+        label: 'Grasslands',
+        primaryLayerName: 'ground layer',
+        secondaryLayerName: 'tree/shrub layers',
+        highlyModifiedIncludesAbsent: false,
+    },
+};
+
+export const BIOME_ORDER: BiomeType[] = ['woodlands', 'shrublands', 'grasslands'];
+
+export const LAYER_CONDITION_ORDER: LayerCondition[] = [
+    'close-to-reference',
+    'modified',
+    'highly-modified',
+    'collapsed-transformer',
+];
+
+// Pretty text for a condition used in the PRIMARY layer of a biome.
+// e.g. 'highly-modified' + woodlands -> "Highly modified/absent"
+export function primaryConditionText(
+    biome: BiomeType,
+    condition: LayerCondition,
+): string {
+    switch (condition) {
+        case 'close-to-reference':
+            return 'Close to reference';
+        case 'modified':
+            return 'Modified';
+        case 'highly-modified':
+            return BIOMES[biome].highlyModifiedIncludesAbsent
+                ? 'Highly modified/absent'
+                : 'Highly modified';
+        case 'collapsed-transformer':
+            return 'Collapsed/transformer';
+    }
+}
+
+// Pretty text for a condition used in the SECONDARY layers of a biome.
+// Mirrors the phrasing in the PDF: for all three biomes the secondary text
+// is "Close to reference" / "Modified" / "Highly modified" / "Collapsed/transformer"
+// (note: no "/absent" is used in any biome's secondary description in the PDF).
+export function secondaryConditionText(condition: LayerCondition): string {
+    switch (condition) {
+        case 'close-to-reference':
+            return 'close to reference';
+        case 'modified':
+            return 'modified';
+        case 'highly-modified':
+            return 'highly modified';
+        case 'collapsed-transformer':
+            return 'collapsed/transformer';
+    }
+}
+
+// "Close to reference tree layer"
+export function primaryGroupLabel(
+    biome: BiomeType,
+    condition: LayerCondition,
+): string {
+    return `${primaryConditionText(biome, condition)} ${BIOMES[biome].primaryLayerName}`;
+}
+
+// "Close to reference tree layer with modified shrub/ground layers"
+export function layerTemplateLabel(
+    biome: BiomeType,
+    primary: LayerCondition,
+    secondary: LayerCondition,
+): string {
+    const cfg = BIOMES[biome];
+    return `${primaryGroupLabel(biome, primary)} with ${secondaryConditionText(secondary)} ${cfg.secondaryLayerName}`;
+}
+
+// ---------- Special (non-layer) templates ----------
+
+// "Cultivated woody" has a single combined template per biome covering
+// modified / highly modified / collapsed-transformer complementary layers.
+export const CULTIVATED_WOODY_SECONDARY = 'mixed-complementary' as const;
+
+// Intensive land uses sub-types (same 3 sub-types across all biomes)
+export type IntensiveKind = 'crops' | 'exotic-pastures' | 'artificial-surfaces';
+
+export const INTENSIVE_ORDER: IntensiveKind[] = [
+    'crops',
+    'exotic-pastures',
+    'artificial-surfaces',
+];
+
+export function intensiveLabel(kind: IntensiveKind): string {
+    switch (kind) {
+        case 'crops':
+            return 'Crops';
+        case 'exotic-pastures':
+            return 'Intensively managed exotic pastures';
+        case 'artificial-surfaces':
+            return 'Artificial surfaces and infrastructure (e.g. buildings, roads, mine pits)';
+    }
+}
+
+// ---------- Template identity ----------
+
+// A NodeTemplate represents one concrete choice from the 3rd-level dropdown.
+// Templates are identified by a stable string id so we can persist them on
+// the node attributes and restore the dropdown state when editing.
+export interface NodeTemplate {
+    readonly id: string;
+    readonly biome: BiomeType;
+    // Second-level (primary group) metadata
+    readonly primaryGroup: PrimaryGroupKind;
+    readonly primaryCondition?: LayerCondition; // only for primaryGroup === 'layer'
+    // Third-level metadata
+    readonly secondaryCondition?: LayerCondition; // for 'layer' group
+    readonly intensiveKind?: IntensiveKind;       // for 'intensive' group
+    // Full human-readable label
+    readonly label: string;
+    // Short label shown in the 3rd-level dropdown (value relative to the
+    // selected primary group). For a layer template this is the "with ..."
+    // phrase; for cultivated/intensive it is just the full label.
+    readonly shortLabel: string;
+    // Second-level group display label (shown in dropdown level 2).
+    readonly groupLabel: string;
+}
+
+function buildLayerTemplate(
+    biome: BiomeType,
+    primary: LayerCondition,
+    secondary: LayerCondition,
+): NodeTemplate {
+    const cfg = BIOMES[biome];
+    return {
+        id: `${biome}.layer.${primary}.${secondary}`,
+        biome,
+        primaryGroup: 'layer',
+        primaryCondition: primary,
+        secondaryCondition: secondary,
+        label: layerTemplateLabel(biome, primary, secondary),
+        shortLabel: `with ${secondaryConditionText(secondary)} ${cfg.secondaryLayerName}`,
+        groupLabel: primaryGroupLabel(biome, primary),
+    };
+}
+
+function buildCultivatedWoodyTemplate(biome: BiomeType): NodeTemplate {
+    const label =
+        'Cultivated woody with modified/highly modified/collapsed/transformer complementary layers';
+    return {
+        id: `${biome}.cultivated-woody`,
+        biome,
+        primaryGroup: 'cultivated-woody',
+        label,
+        shortLabel: label,
+        groupLabel: 'Cultivated woody',
+    };
+}
+
+function buildIntensiveTemplate(
+    biome: BiomeType,
+    kind: IntensiveKind,
+): NodeTemplate {
+    return {
+        id: `${biome}.intensive.${kind}`,
+        biome,
+        primaryGroup: 'intensive',
+        intensiveKind: kind,
+        label: intensiveLabel(kind),
+        shortLabel: intensiveLabel(kind),
+        groupLabel: 'Intensive land uses',
+    };
+}
+
+// Full flat list of all templates, generated once at module load.
+export const NODE_TEMPLATES: NodeTemplate[] = (() => {
+    const templates: NodeTemplate[] = [];
+    for (const biome of BIOME_ORDER) {
+        // 16 layer templates per biome (4 primary x 4 secondary)
+        for (const primary of LAYER_CONDITION_ORDER) {
+            for (const secondary of LAYER_CONDITION_ORDER) {
+                templates.push(buildLayerTemplate(biome, primary, secondary));
+            }
+        }
+        // Cultivated woody (1 per biome)
+        templates.push(buildCultivatedWoodyTemplate(biome));
+        // Intensive land uses (3 per biome)
+        for (const kind of INTENSIVE_ORDER) {
+            templates.push(buildIntensiveTemplate(biome, kind));
+        }
+    }
+    return templates;
+})();
+
+export const TEMPLATES_BY_ID: Record<string, NodeTemplate> = NODE_TEMPLATES.reduce(
+    (acc, t) => {
+        acc[t.id] = t;
+        return acc;
+    },
+    {} as Record<string, NodeTemplate>,
+);
+
+// ---------- Dropdown helpers ----------
+
+export interface PrimaryGroupOption {
+    readonly key: string;              // unique per (biome + group)
+    readonly kind: PrimaryGroupKind;
+    readonly condition?: LayerCondition; // for 'layer' group
+    readonly label: string;
+}
+
+export function listPrimaryGroupOptions(biome: BiomeType): PrimaryGroupOption[] {
+    const options: PrimaryGroupOption[] = [];
+    for (const cond of LAYER_CONDITION_ORDER) {
+        options.push({
+            key: `layer.${cond}`,
+            kind: 'layer',
+            condition: cond,
+            label: primaryGroupLabel(biome, cond),
+        });
+    }
+    options.push({
+        key: 'cultivated-woody',
+        kind: 'cultivated-woody',
+        label: 'Cultivated woody',
+    });
+    options.push({
+        key: 'intensive',
+        kind: 'intensive',
+        label: 'Intensive land uses',
+    });
+    return options;
+}
+
+export function listTemplatesForGroup(
+    biome: BiomeType,
+    groupKey: string,
+): NodeTemplate[] {
+    return NODE_TEMPLATES.filter((t) => {
+        if (t.biome !== biome) return false;
+        if (t.primaryGroup === 'layer') {
+            return groupKey === `layer.${t.primaryCondition}`;
+        }
+        return groupKey === t.primaryGroup;
+    });
+}
+
+export function primaryGroupKeyOf(template: NodeTemplate): string {
+    if (template.primaryGroup === 'layer') {
+        return `layer.${template.primaryCondition}`;
+    }
+    return template.primaryGroup;
+}
+
+// Lightweight reference we persist on NodeAttributes so the dropdowns can be
+// rehydrated when editing an existing node.
+export interface TemplateRef {
+    readonly id: string;
+    readonly biome: BiomeType;
+    readonly label: string;
+}
+
+export function makeTemplateRef(template: NodeTemplate): TemplateRef {
+    return { id: template.id, biome: template.biome, label: template.label };
+}


### PR DESCRIPTION
Summary
This PR bundles a set of UX and correctness improvements to the STM canvas editor. All changes are independent and each closes a tracked issue.

Changes
🐛 Fix: Edges connecting new nodes are now editable after creation
Nodes created via Add Node were assigned a timestamp-based React Flow id (node-${Date.now()}), which is incompatible with the state-N format expected by parseStateId(). This caused transition creation and double-click editing to silently fail for any edge connecting a freshly-added node. The fix aligns the React Flow node id with the BMRG frontend_state_id at creation time.

📐 Reduce node box size for better canvas density · Closes [#55](https://github.com/Chou-Haoran/stm_creator-frontend/issues/55)
.node-container width 192px → 168px, min-height 80px → 76px
.state-name font-size 11.5px → 10.5px, line-height 1.4 → 1.35
Lock indicator max-width adjusted proportionally
🏷️ Rename "VAST class" → "Condition class" in UI · Closes [#56](https://github.com/Chou-Haoran/stm_creator-frontend/issues/56)
All user-facing "VAST" labels replaced with "Condition class". Underlying data fields (vastClass / vast_class) are unchanged to avoid a schema migration.

🎨 Transition edge colour by delta direction · Closes [#57](https://github.com/Chou-Haoran/stm_creator-frontend/issues/57)
Edge colour now reflects transition delta value:

Positive → green (#55aa55)
Negative → red (#ff5555)
Zero → gray (#9ca3af)
Arrow markers inherit the edge colour automatically.

🖱️ Right-click context menu for states and transitions · Closes [#58](https://github.com/Chou-Haoran/stm_creator-frontend/issues/58)
Right-clicking a state node or transition edge opens a floating context menu with Edit and Delete actions.

Edit reuses the existing modal flow (including lock-acquire for nodes)
Delete is now optimistic — the canvas updates immediately, even if the backend returns 404 (e.g. for an unsaved transition). Failures are logged as warnings without rolling back, keeping the UI consistent
🗺️ Condition class colour legend with collapse toggle · Closes [#59](https://github.com/Chou-Haoran/stm_creator-frontend/issues/59)
Legend swatches now use the exact same hex values as the rendered nodes (verified programmatically)
Legend header is a collapse/expand toggle (▾ ↔ ▸) with state persisted to localStorage (stmCreator.legendCollapsed)