### PR TITLE
SCRUM-159/160/164 Add template docs and comment resolve support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -396,7 +396,9 @@ function GraphEditor() {
         const mentionToken = `@[${label}]`;
 
         const count = comments.filter((comment: any) =>
-          typeof comment?.text === 'string' && comment.text.includes(mentionToken)
+          typeof comment?.text === 'string' &&
+          !comment?.resolved &&
+          comment.text.includes(mentionToken)
         ).length;
 
         counts[node.id] = count;

--- a/src/app/components/CommentPanel.tsx
+++ b/src/app/components/CommentPanel.tsx
@@ -6,6 +6,9 @@ export interface CommentEntry {
     text: string;
     author: string;
     createdAt: string;
+    resolved?: boolean;
+    resolvedAt?: string;
+    resolvedBy?: string;
 }
 
 /** An @-mentionable item (node or edge) */
@@ -45,6 +48,7 @@ export function CommentPanel({ onClose, nodes, edges, userEmail, modelName }: Co
     const [showMentions, setShowMentions] = useState(false);
     const [mentionFilter, setMentionFilter] = useState('');
     const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+    const [showResolved, setShowResolved] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     // Reload comments when model changes
@@ -104,6 +108,7 @@ export function CommentPanel({ onClose, nodes, edges, userEmail, modelName }: Co
             text: text.trim(),
             author: userEmail || 'Guest',
             createdAt: new Date().toISOString(),
+            resolved: false,
         };
         const next = [entry, ...comments];
         setComments(next);
@@ -111,13 +116,48 @@ export function CommentPanel({ onClose, nodes, edges, userEmail, modelName }: Co
         setText('');
     };
 
+    const updateComments = (next: CommentEntry[]) => {
+        setComments(next);
+        saveComments(modelName, next);
+    };
+
+    const resolveComment = (commentId: string) => {
+        const next = comments.map(c =>
+            c.id === commentId
+                ? {
+                    ...c,
+                    resolved: true,
+                    resolvedAt: new Date().toISOString(),
+                    resolvedBy: userEmail || 'Guest',
+                }
+                : c
+        );
+        updateComments(next);
+    };
+
+    const reopenComment = (commentId: string) => {
+        const next = comments.map(c =>
+            c.id === commentId
+                ? {
+                    ...c,
+                    resolved: false,
+                    resolvedAt: undefined,
+                    resolvedBy: undefined,
+                }
+                : c
+        );
+        updateComments(next);
+    };
+
     const confirmDelete = () => {
         if (!pendingDeleteId) return;
         const next = comments.filter(c => c.id !== pendingDeleteId);
-        setComments(next);
-        saveComments(modelName, next);
+        updateComments(next);
         setPendingDeleteId(null);
     };
+
+    const unresolvedComments = comments.filter(c => !c.resolved);
+    const resolvedComments = comments.filter(c => c.resolved);
 
     /** Render comment text with @[...] mentions highlighted */
     const renderText = (raw: string) => {
@@ -189,21 +229,73 @@ export function CommentPanel({ onClose, nodes, edges, userEmail, modelName }: Co
                 {comments.length === 0 ? (
                     <p style={emptyText}>No comments yet.</p>
                 ) : (
-                    comments.map(c => (
-                        <div key={c.id} style={commentCard}>
-                            <div style={commentHeader}>
-                                <span style={authorStyle}>{c.author}</span>
-                                <span style={dateStyle}>{new Date(c.createdAt).toLocaleString()}</span>
+                    <>
+                        {unresolvedComments.length === 0 ? (
+                            <p style={emptyText}>No open comments.</p>
+                        ) : (
+                            unresolvedComments.map(c => (
+                                <div key={c.id} style={commentCard}>
+                                    <div style={commentHeader}>
+                                        <span style={authorStyle}>{c.author}</span>
+                                        <span style={dateStyle}>{new Date(c.createdAt).toLocaleString()}</span>
+                                    </div>
+                                    <div style={commentText}>{renderText(c.text)}</div>
+                                    <div style={commentActions}>
+                                        <button
+                                            onClick={() => resolveComment(c.id)}
+                                            style={resolveBtnStyle}
+                                        >
+                                            Resolve
+                                        </button>
+                                        <button
+                                            onClick={() => setPendingDeleteId(c.id)}
+                                            style={deleteBtnStyle}
+                                        >
+                                            Delete
+                                        </button>
+                                    </div>
+                                </div>
+                            ))
+                        )}
+
+                        {resolvedComments.length > 0 && (
+                            <div style={resolvedSection}>
+                                <button
+                                    onClick={() => setShowResolved(prev => !prev)}
+                                    style={resolvedToggleStyle}
+                                >
+                                    {showResolved ? 'Hide' : 'Show'} resolved comments ({resolvedComments.length})
+                                </button>
+
+                                {showResolved && resolvedComments.map(c => (
+                                    <div key={c.id} style={resolvedCommentCard}>
+                                        <div style={commentHeader}>
+                                            <span style={authorStyle}>{c.author}</span>
+                                            <span style={dateStyle}>{new Date(c.createdAt).toLocaleString()}</span>
+                                        </div>
+                                        <div style={resolvedMetaText}>
+                                            Resolved{c.resolvedBy ? ` by ${c.resolvedBy}` : ''}{c.resolvedAt ? ` at ${new Date(c.resolvedAt).toLocaleString()}` : ''}
+                                        </div>
+                                        <div style={commentText}>{renderText(c.text)}</div>
+                                        <div style={commentActions}>
+                                            <button
+                                                onClick={() => reopenComment(c.id)}
+                                                style={reopenBtnStyle}
+                                            >
+                                                Reopen
+                                            </button>
+                                            <button
+                                                onClick={() => setPendingDeleteId(c.id)}
+                                                style={deleteBtnStyle}
+                                            >
+                                                Delete
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
                             </div>
-                            <div style={commentText}>{renderText(c.text)}</div>
-                            <button
-                                onClick={() => setPendingDeleteId(c.id)}
-                                style={deleteBtnStyle}
-                            >
-                                Delete
-                            </button>
-                        </div>
-                    ))
+                        )}
+                    </>
                 )}
             </div>
 
@@ -353,6 +445,63 @@ const mentionHighlight: React.CSSProperties = {
     background: 'rgba(16, 185, 129, 0.1)',
     borderRadius: 3,
     padding: '0 2px',
+};
+
+const commentActions: React.CSSProperties = {
+    display: 'flex',
+    gap: 10,
+    alignItems: 'center',
+};
+
+const resolveBtnStyle: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    color: '#059669',
+    fontSize: 11,
+    cursor: 'pointer',
+    padding: 0,
+    fontWeight: 600,
+};
+
+const reopenBtnStyle: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    color: '#2563eb',
+    fontSize: 11,
+    cursor: 'pointer',
+    padding: 0,
+    fontWeight: 600,
+};
+
+const resolvedSection: React.CSSProperties = {
+    marginTop: 12,
+    paddingTop: 10,
+    borderTop: '1px solid var(--border, #e5e7eb)',
+};
+
+const resolvedToggleStyle: React.CSSProperties = {
+    width: '100%',
+    background: 'var(--surface2, #f9fafb)',
+    border: '1px solid var(--border, #e5e7eb)',
+    borderRadius: 6,
+    padding: '6px 8px',
+    fontSize: 12,
+    color: 'var(--text, #064e3b)',
+    cursor: 'pointer',
+    marginBottom: 8,
+    textAlign: 'left',
+};
+
+const resolvedCommentCard: React.CSSProperties = {
+    ...commentCard,
+    opacity: 0.72,
+    background: '#f3f4f6',
+};
+
+const resolvedMetaText: React.CSSProperties = {
+    fontSize: 10,
+    color: 'var(--text-muted, #6b7280)',
+    marginBottom: 6,
 };
 
 const deleteBtnStyle: React.CSSProperties = {

--- a/template-first-workflow.md
+++ b/template-first-workflow.md
@@ -1,0 +1,176 @@
+# Template-first Workflow and Matrix Layout
+
+This document defines the initial design rules for the STM template layout and the template-first model creation workflow.
+
+It covers:
+
+- SCRUM-159: Matrix layout for templates
+- SCRUM-160: Template-first workflow
+
+---
+
+## SCRUM-159: Matrix Layout for Templates
+
+The template matrix layout is used to arrange state boxes in a consistent and predictable structure when a user loads an STM template.
+
+The layout is based on two ecological condition dimensions:
+
+1. **Overstory condition**
+2. **Understory condition**
+
+### Layout Rules
+
+The horizontal axis represents **overstory condition**.
+
+- Better overstory condition appears on the left.
+- More degraded overstory condition appears towards the right.
+
+The vertical axis represents **understory condition**.
+
+- Better understory condition appears at the top.
+- More degraded understory condition appears towards the bottom.
+
+The worst combined condition should be placed in the **bottom-right corner**.
+
+This means the bottom-right state represents both:
+
+- poor overstory condition
+- poor understory condition
+
+### Matrix Structure
+
+```text
+                         Overstory condition
+                  Better  -------------------->  Worse
+
+Understory     +----------------+----------------+----------------+
+Better         | State A        | State B        | State C        |
+               | Good overstory | Mid overstory  | Poor overstory |
+               +----------------+----------------+----------------+
+               | State D        | State E        | State F        |
+               | Good overstory | Mid overstory  | Poor overstory |
+               +----------------+----------------+----------------+
+Worse          | State G        | State H        | Worst State    |
+               | Good overstory | Mid overstory  | Poor overstory |
+               +----------------+----------------+----------------+
+```
+
+---
+
+## Design Rationale
+
+This layout helps users understand the template more quickly because ecological degradation is shown in a clear spatial direction.
+
+The model becomes easier to read because:
+
+- condition quality decreases from left to right for overstory
+- condition quality decreases from top to bottom for understory
+- the worst state is always in the same expected location
+- users can compare states by their position in the matrix
+
+This also makes different templates more consistent with each other.
+
+---
+
+## SCRUM-160: Template-first Workflow
+
+The template-first workflow allows users to start from a predefined STM template instead of creating every state from an empty canvas.
+
+This workflow is intended to reduce setup time and help users build models using a consistent structure.
+
+### Workflow Overview
+
+```text
+Select template
+      ↓
+Load template onto canvas
+      ↓
+Review template states
+      ↓
+Delete irrelevant states
+      ↓
+Add or edit transitions
+      ↓
+Edit transition attributes
+      ↓
+Save customised model
+```
+
+### Detailed Workflow
+
+#### 1. Select a Template
+
+The user starts by selecting a predefined STM template.
+
+The template may be based on vegetation type, ecological context, or a common modelling pattern.
+
+#### 2. Load the Template
+
+After the user selects a template, the system loads the template onto the canvas.
+
+The states should be arranged using the matrix layout defined in SCRUM-159.
+
+#### 3. Review Template States
+
+The user reviews the generated states and checks whether each state is relevant to the current project.
+
+Some templates may contain more states than are needed for a specific ecosystem or use case.
+
+#### 4. Delete Irrelevant States
+
+The user removes states that are not relevant to the current model.
+
+This allows the template to act as a starting point, rather than a fixed structure.
+
+#### 5. Add or Edit Transitions
+
+After the relevant states have been kept, the user adds transitions between states.
+
+The user may also edit existing transitions if the template includes default transitions.
+
+#### 6. Edit Transition Attributes
+
+For each transition, the user can edit transition details such as:
+
+- transition driver
+- likelihood
+- time scale
+- transition notes
+- preconditions
+- supporting evidence
+
+#### 7. Save the Customised Model
+
+Once the template has been adjusted, the user saves the customised model.
+
+The saved result becomes a project-specific STM model based on the original template.
+
+---
+
+## Expected First-version Behaviour
+
+For the first version, the template-first workflow should focus on a simple and reliable user path:
+
+1. User selects a template.
+2. System places template states on the canvas.
+3. User deletes states that are not needed.
+4. User adds or edits transitions.
+5. User saves the customised model.
+
+Advanced template editing features can be considered in later versions.
+
+---
+
+## Acceptance Notes
+
+The design satisfies SCRUM-159 by defining:
+
+- overstory condition arranged left to right
+- understory condition arranged top to bottom
+- worst combined state placed at the bottom-right corner
+
+The design satisfies SCRUM-160 by defining:
+
+- the template-first workflow
+- the main user steps from loading a template to saving a customised model
+- how users remove irrelevant states and add transitions


### PR DESCRIPTION
## Summary

This PR completes SCRUM-159, SCRUM-160, and SCRUM-164.

It adds a root-level `template-first-workflow.md` document for the template matrix layout and template-first workflow, and implements resolve behaviour for the comment system.

## Changes

### SCRUM-159: Template matrix layout

- Added documentation for the template matrix layout.
- Defined overstory condition as left-to-right.
- Defined understory condition as top-to-bottom.
- Defined the worst combined state as the bottom-right state.
- Added a simple matrix structure to explain the expected template layout.

### SCRUM-160: Template-first workflow

- Documented the template-first model creation workflow.
- Defined the main workflow from selecting a template to saving a customised model.
- Included first-version behaviour for loading templates, deleting irrelevant states, adding transitions, and saving the customised model.

### SCRUM-164: Comment resolve support

- Added resolve support for comments.
- Added resolved comment metadata: `resolved`, `resolvedAt`, and `resolvedBy`.
- Added a `Resolve` action for open comments.
- Added a separate resolved comments section.
- Added `Reopen` support for resolved comments.
- Kept delete support for both open and resolved comments.
- Updated comment bubble counting so resolved comments are not treated as open comments.

## Testing

- Created a new comment.
- Confirmed the comment appears as an open comment.
- Clicked `Resolve` and confirmed the comment moves into the resolved comments section.
- Confirmed resolved comments can be shown or hidden.
- Confirmed a resolved comment can be reopened.
- Confirmed delete still works for comments.
- Confirmed resolved comments are no longer counted as open comments in the comment bubble.

## Notes

The template matrix layout and template-first workflow are documented as design/specification work for the first version. Advanced template editing behaviour can be considered in a later iteration.