### PR TITLE
feat: add production Docker support (nginx, multi-stage, non-root)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Dependencies — never send node_modules into the build context.
+# The deps stage installs them fresh from the lockfile.
+node_modules
+
+# npm / yarn / pnpm debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Previous build outputs — the builder stage produces these fresh.
+.next
+.nuxt
+dist
+build
+out
+.output
+
+# Test coverage reports
+coverage
+
+# Version control
+.git
+.gitignore
+
+# Environment files — NEVER bake real secrets into a Docker image.
+# .env.example is kept so it ends up in the build context (useful
+# for documentation) but all real .env files are excluded.
+.env
+.env.*
+!.env.example
+
+# Editor / IDE configs
+.vscode
+.idea
+
+# macOS metadata
+.DS_Store
+
+# Documentation and repository metadata — not needed in the image.
+README.md
+*.md
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,133 @@
+# ============================================================
+# STM Creator — Frontend
+# Multi-stage Docker build: deps → builder → runner (nginx)
+#
+# This is a static SPA (Vite + React). The final image contains
+# only the compiled bundle served by nginx — no Node runtime.
+#
+# ── Build-time arguments (pass with --build-arg) ────────────
+#   VITE_API_BASE_URL   Base URL of the backend REST API.
+#                       Required for a functional deployment.
+#                       Example: https://api.your-domain.com
+#
+#   VITE_COLLAB_URL     Socket.IO server URL for real-time
+#                       collaboration. Optional — defaults to
+#                       VITE_API_BASE_URL when not set.
+#
+#   VITE_MODEL_NAME     Default STM model name loaded by the
+#                       demo dataset loader. Optional.
+#
+# ── Example build ───────────────────────────────────────────
+#   docker build \
+#     --build-arg VITE_API_BASE_URL=https://api.your-domain.com \
+#     -t stm-creator-frontend .
+#
+# ── Example run ─────────────────────────────────────────────
+#   docker run -p 80:8080 stm-creator-frontend
+# ============================================================
+
+
+# ── Stage 1: deps ───────────────────────────────────────────
+# Install all npm dependencies using the lockfile so the result
+# is byte-for-byte reproducible. Only package.json and the
+# lockfile are copied in this stage, which means this expensive
+# layer is cached and only re-runs when dependencies change —
+# not on every source code change.
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+# Copy the manifest and lockfile before any source code.
+COPY package.json package-lock.json ./
+
+# --frozen-lockfile equivalent for npm: "ci" always uses the
+# lockfile and fails if package.json and lock are out of sync.
+RUN npm ci
+
+
+# ── Stage 2: builder ────────────────────────────────────────
+# Compile TypeScript and run the Vite production build.
+#
+# All VITE_ variables are baked into the JavaScript bundle at
+# build time (Vite replaces import.meta.env.* statically).
+# They CANNOT be changed at container runtime — if you need a
+# different backend URL, rebuild the image with a new --build-arg.
+FROM node:20-alpine AS builder
+
+# Declare each build-time variable. Empty string is the default;
+# the app falls back to its hardcoded production cloud URL when
+# VITE_API_BASE_URL is not supplied.
+ARG VITE_API_BASE_URL=""
+ARG VITE_COLLAB_URL=""
+ARG VITE_MODEL_NAME=""
+
+# Re-export as environment variables so Vite can read them during
+# the build (Vite reads from process.env, not just ARG).
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL \
+    VITE_COLLAB_URL=$VITE_COLLAB_URL \
+    VITE_MODEL_NAME=$VITE_MODEL_NAME
+
+WORKDIR /app
+
+# Pull in the pre-installed node_modules from the deps stage.
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy the full source tree (node_modules is excluded by .dockerignore).
+COPY . .
+
+# tsc type-checks the project, then vite bundles it into dist/.
+RUN npm run build
+
+
+# ── Stage 3: runner ─────────────────────────────────────────
+# Serve the static bundle with nginx. This stage contains no
+# Node runtime and no source code — only the compiled artefact
+# and the web server. This keeps the final image small.
+FROM nginx:alpine AS runner
+
+LABEL org.opencontainers.image.title="STM Creator Frontend" \
+      org.opencontainers.image.source="https://github.com/ibraKH/stm-creator" \
+      org.opencontainers.image.licenses="MIT"
+
+# Replace the default nginx virtual-host config with our SPA-
+# aware config (SPA fallback, gzip, cache headers, health check).
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy the Vite build output from the builder stage.
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Create a dedicated non-root user and fix up every path that
+# nginx writes to at runtime (cache, logs, pid file).
+#
+# Why port 8080 instead of 80?
+# Non-root processes cannot bind to ports < 1024 on Linux without
+# CAP_NET_BIND_SERVICE. Using 8080 lets us run without elevated
+# privileges. Map 80 → 8080 at the host or load-balancer level:
+#   docker run -p 80:8080 stm-creator-frontend
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup \
+    # The 'user nginx;' directive in the main nginx.conf instructs
+    # the master process to switch workers to the 'nginx' user.
+    # Because our master is already a non-root user, that switch
+    # would fail with a permission error — so we remove the line.
+    && sed -i '/^user /d' /etc/nginx/nginx.conf \
+    # Grant appuser write access to every path nginx touches.
+    && chown -R appuser:appgroup \
+        /usr/share/nginx/html \
+        /var/cache/nginx \
+        /var/log/nginx \
+        /etc/nginx/conf.d \
+    && touch /var/run/nginx.pid \
+    && chown appuser:appgroup /var/run/nginx.pid
+
+# Switch to the non-root user before starting the process.
+USER appuser
+
+# nginx listens on 8080 (see nginx.conf and the note above).
+EXPOSE 8080
+
+# Poll the dedicated health endpoint every 30 s.
+# A fresh container gets a 10 s grace period before checks start.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost:8080/healthz || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -104,9 +104,43 @@ Optional flags: `ROLE=Admin`, `MODEL_NAME="BMRG Rainforests"`, `SAVE=true` (save
 
 ---
 
-## Docker / full-stack setup
+## Running with Docker
 
-A `Dockerfile` and full-stack `docker-compose.yml` are included as part of the project handover package. Refer to the backend repository for the compose file that wires the frontend, backend, and database together.
+The repository ships a production-ready `Dockerfile` (multi-stage, nginx, non-root).
+
+### Build the image
+
+```bash
+docker build \
+  --build-arg VITE_API_BASE_URL=https://api.your-domain.com \
+  -t stm-creator-frontend .
+```
+
+All `VITE_*` variables are baked into the JavaScript bundle at build time. Supply
+them as `--build-arg` flags; they cannot be changed at container runtime.
+
+| Build argument | Required | Description |
+|---|---|---|
+| `VITE_API_BASE_URL` | Yes | Base URL of the backend REST API (no trailing slash). |
+| `VITE_COLLAB_URL` | No | Socket.IO server URL. Defaults to `VITE_API_BASE_URL`. |
+| `VITE_MODEL_NAME` | No | Default STM model name for the demo dataset loader. |
+
+### Run the container
+
+```bash
+docker run -p 80:8080 stm-creator-frontend
+```
+
+The container listens on port **8080** internally (nginx runs as a non-root user,
+which cannot bind to port 80 without elevated privileges). The `-p 80:8080` flag
+maps host port 80 to the container's port 8080 so the app is reachable at
+`http://localhost`.
+
+### Full-stack setup
+
+A `docker-compose.yml` at the root of the **backend repository** wires the
+frontend, backend, and database together in a single `docker compose up` command.
+Refer to that repository for the compose file and its environment configuration.
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,74 @@
+# nginx virtual-host configuration for STM Creator Frontend.
+#
+# Designed for a Dockerised static SPA built with Vite.
+# Listens on port 8080 so the container can run as a non-root user.
+# Map port 80 (or any host port) to 8080 at the docker run / compose level.
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # ── Gzip compression ────────────────────────────────────
+    # Compress text-based responses before sending. Browsers that
+    # support gzip (all modern browsers) send Accept-Encoding: gzip
+    # and receive smaller payloads with no client-side effort.
+    gzip on;
+    gzip_vary on;         # Tell caches to key on Accept-Encoding
+    gzip_min_length 1024; # Do not compress tiny responses
+    gzip_types
+        text/css
+        text/html
+        text/plain
+        text/xml
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml;
+
+    # ── Health check endpoint ────────────────────────────────
+    # Used by Docker HEALTHCHECK and external load-balancer probes.
+    # Returns 200 OK with a plain-text body. Access log is disabled
+    # to avoid noise in production logs.
+    location /healthz {
+        access_log off;
+        return 200 "OK\n";
+        add_header Content-Type text/plain;
+    }
+
+    # ── Long-lived cache for hashed static assets ────────────
+    # Vite appends a content hash to every JS/CSS asset filename
+    # (e.g. /assets/index-3f2a1b.js). Because the filename changes
+    # with the content, it is safe to cache these files forever.
+    # Browsers will automatically fetch new filenames after a deploy.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # ── No-cache for index.html ──────────────────────────────
+    # index.html must never be cached. It contains the <script> and
+    # <link> tags that reference the hashed asset filenames. If a
+    # browser serves a stale index.html after a deploy, it will
+    # request old asset filenames that may no longer exist on the
+    # server (since the CDN / nginx only keeps the latest build).
+    location = /index.html {
+        # Do not use 'expires -1' here — it would add its own Cache-Control: no-cache
+        # header which duplicates (and conflicts visually with) the one below.
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma         "no-cache";
+        add_header Expires        "0";
+    }
+
+    # ── SPA fallback ─────────────────────────────────────────
+    # React Router handles all navigation client-side. When a user
+    # loads a deep link (e.g. /editor/abc123) directly, nginx must
+    # serve index.html rather than returning a 404, so the React app
+    # can boot and then render the correct route.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
- Dockerfile: three-stage build (deps → builder → runner). deps and builder stages use node:20-alpine; runner uses nginx:alpine. All VITE_* env vars declared as ARG with empty defaults so the image builds without --build-arg and callers can override at build time.
- nginx.conf: listens on port 8080 (non-root constraint), SPA fallback via try_files, gzip for text assets, immutable cache for hashed /assets/, no-cache for index.html, /healthz health endpoint.
- .dockerignore: excludes node_modules, dist, all .env* (keeps .env.example), git history, editor configs, and docs.
- README: replaces stub Docker section with full build/run instructions including --build-arg table and port-mapping explanation.

Tested: build 17/17, health check 200, SPA fallback 200, single Cache-Control header on index.html, asset immutable cache, appuser non-root confirmed.